### PR TITLE
Implement differentiable version of _get_dt_array function

### DIFF
--- a/diffstar/stars.py
+++ b/diffstar/stars.py
@@ -34,13 +34,15 @@ _SFR_PARAM_BOUNDS = OrderedDict(
 
 
 def calculate_sigmoid_bounds(param_bounds):
+    bounds_out = OrderedDict()
+
     for key in param_bounds:
         _bounds = (
             float(np.mean(param_bounds[key])),
             abs(float(4.0 / np.diff(param_bounds[key]))),
         )
-        param_bounds[key] = _bounds + param_bounds[key]
-    return param_bounds
+        bounds_out[key] = _bounds + param_bounds[key]
+    return bounds_out
 
 
 SFR_PARAM_BOUNDS = calculate_sigmoid_bounds(_SFR_PARAM_BOUNDS)

--- a/diffstar/tests/test_stars.py
+++ b/diffstar/tests/test_stars.py
@@ -1,12 +1,8 @@
 """
 """
-from ..stars import MS_PARAM_BOUNDS, DEFAULT_MS_PARAMS
-from ..stars import DEFAULT_Q_PARAMS, Q_PARAM_BOUNDS
+from ..stars import DEFAULT_SFR_PARAMS, _SFR_PARAM_BOUNDS
 
 
 def test_sfh_parameter_bounds():
-    for key, val in DEFAULT_MS_PARAMS.items():
-        assert MS_PARAM_BOUNDS[key][0] < val < MS_PARAM_BOUNDS[key][1]
-
-    for key, val in DEFAULT_Q_PARAMS.items():
-        assert Q_PARAM_BOUNDS[key][0] < val < Q_PARAM_BOUNDS[key][1]
+    for key, val in DEFAULT_SFR_PARAMS.items():
+        assert _SFR_PARAM_BOUNDS[key][0] < val < _SFR_PARAM_BOUNDS[key][1]

--- a/diffstar/tests/test_utils.py
+++ b/diffstar/tests/test_utils.py
@@ -1,0 +1,23 @@
+"""
+"""
+import numpy as np
+from jax import random as jran
+from ..utils import _jax_get_dt_array, _get_dt_array
+
+
+def test_jax_get_dt_array_linspace():
+    tarr = np.linspace(1, 13.8, 50)
+    dtarr_np = _get_dt_array(tarr)
+    dtarr_jnp = _jax_get_dt_array(tarr)
+    assert np.allclose(dtarr_np, dtarr_jnp, atol=0.01)
+
+
+def test_jax_get_dt_array_random():
+    n_tests = 10
+    ran_key = jran.PRNGKey(0)
+    for __ in range(n_tests):
+        ran_key, key = jran.split(ran_key, 2)
+        tarr = np.sort(jran.uniform(key, minval=0, maxval=14, shape=(50,)))
+        dtarr_np = _get_dt_array(tarr)
+        dtarr_jnp = _jax_get_dt_array(tarr)
+        assert np.allclose(dtarr_np, dtarr_jnp, atol=0.01)

--- a/diffstar/utils.py
+++ b/diffstar/utils.py
@@ -8,6 +8,22 @@ from jax.example_libraries import optimizers as jax_opt
 from jax import jit as jjit
 
 
+@jjit
+def _jax_get_dt_array(t):
+    dt = jnp.zeros_like(t)
+    tmids = 0.5 * (t[:-1] + t[1:])
+    dtmids = jnp.diff(tmids)
+
+    dt = dt.at[1:-1].set(dtmids)
+
+    t_lo = t[0] - (t[1] - t[0]) / 2
+    t_hi = t[-1] + dtmids[-1] / 2
+
+    dt = dt.at[0].set(tmids[0] - t_lo)
+    dt = dt.at[-1].set(t_hi - tmids[-1])
+    return dt
+
+
 def _get_dt_array(t):
     """Compute delta time from input time.
 


### PR DESCRIPTION
The utils.py module now includes `_jax_get_dt_array`, a jitted version of `_get_dt_array`. Some unit tests enforce agreement between the old and new implementation.