### PR TITLE
Remove duplicate function definitions

### DIFF
--- a/diffstar/stars.py
+++ b/diffstar/stars.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import numpy as np
 from diffmah.individual_halo_assembly import _calc_halo_history
 from .quenching import quenching_function
-from .utils import _sigmoid, _inverse_sigmoid, _get_dt_array
+from .utils import _sigmoid, _inverse_sigmoid, _get_dt_array, tw_bin_jax_kern
 from .gas import _get_lagged_gas
 
 TODAY = 13.8
@@ -524,69 +524,6 @@ def _gas_conversion_kern(t_form, t_acc, dt, tau_dep):
         t_form,
     )
     return tri_kern
-
-
-@jjit
-def tw_cuml_jax_kern(x, m, h):
-    """CDF of the triweight kernel.
-
-    Parameters
-    ----------
-    x : array-like or scalar
-        The value at which to evaluate the kernel.
-    m : array-like or scalar
-        The mean of the kernel.
-    h : array-like or scalar
-        The approximate 1-sigma width of the kernel.
-
-    Returns
-    -------
-    kern_cdf : array-like or scalar
-        The value of the kernel CDF.
-
-    """
-    y = (x - m) / h
-    return lax.cond(
-        y < -3,
-        lambda x: 0.0,
-        lambda x: lax.cond(
-            x > 3,
-            lambda xx: 1.0,
-            lambda xx: (
-                -5 * xx**7 / 69984
-                + 7 * xx**5 / 2592
-                - 35 * xx**3 / 864
-                + 35 * xx / 96
-                + 1 / 2
-            ),
-            x,
-        ),
-        y,
-    )
-
-
-@jjit
-def tw_bin_jax_kern(m, h, L, H):
-    """Integrated bin weight for the triweight kernel.
-
-    Parameters
-    ----------
-    m : array-like or scalar
-        The value at which to evaluate the kernel.
-    h : array-like or scalar
-        The approximate 1-sigma width of the kernel.
-    L : array-like or scalar
-        The lower bin limit.
-    H : array-like or scalar
-        The upper bin limit.
-
-    Returns
-    -------
-    bin_prob : array-like or scalar
-        The value of the kernel integrated over the bin.
-
-    """
-    return tw_cuml_jax_kern(H, m, h) - tw_cuml_jax_kern(L, m, h)
 
 
 @jjit

--- a/diffstar/stars.py
+++ b/diffstar/stars.py
@@ -9,6 +9,7 @@ import numpy as np
 from diffmah.individual_halo_assembly import _calc_halo_history
 from .quenching import quenching_function
 from .utils import _sigmoid, _inverse_sigmoid, _get_dt_array, tw_bin_jax_kern
+from .utils import jax_np_interp
 from .gas import _get_lagged_gas
 
 TODAY = 13.8
@@ -524,38 +525,6 @@ def _gas_conversion_kern(t_form, t_acc, dt, tau_dep):
         t_form,
     )
     return tri_kern
-
-
-@jjit
-def jax_np_interp(x, xt, yt, indx_hi):
-    """JAX-friendly implementation of np.interp.
-    Requires indx_hi to be precomputed, e.g., using np.searchsorted.
-
-    Parameters
-    ----------
-    x : ndarray of shape (n, )
-        Abscissa values in the interpolation
-    xt : ndarray of shape (k, )
-        Lookup table for the abscissa
-    yt : ndarray of shape (k, )
-        Lookup table for the ordinates
-
-    Returns
-    -------
-    y : ndarray of shape (n, )
-        Result of linear interpolation
-
-    """
-    indx_lo = indx_hi - 1
-    xt_lo = xt[indx_lo]
-    xt_hi = xt[indx_hi]
-    dx_tot = xt_hi - xt_lo
-    yt_lo = yt[indx_lo]
-    yt_hi = yt[indx_hi]
-    dy_tot = yt_hi - yt_lo
-    m = dy_tot / dx_tot
-    y = yt_lo + m * (x - xt_lo)
-    return y
 
 
 def fstar_tools(t_sim, fstar_tdelay=1.0):

--- a/diffstar/utils.py
+++ b/diffstar/utils.py
@@ -490,3 +490,35 @@ def tw_bin_jax_kern(m, h, L, H):
 
     """
     return tw_cuml_jax_kern(H, m, h) - tw_cuml_jax_kern(L, m, h)
+
+
+@jjit
+def jax_np_interp(x, xt, yt, indx_hi):
+    """JAX-friendly implementation of np.interp.
+    Requires indx_hi to be precomputed, e.g., using np.searchsorted.
+
+    Parameters
+    ----------
+    x : ndarray of shape (n, )
+        Abscissa values in the interpolation
+    xt : ndarray of shape (k, )
+        Lookup table for the abscissa
+    yt : ndarray of shape (k, )
+        Lookup table for the ordinates
+
+    Returns
+    -------
+    y : ndarray of shape (n, )
+        Result of linear interpolation
+
+    """
+    indx_lo = indx_hi - 1
+    xt_lo = xt[indx_lo]
+    xt_hi = xt[indx_hi]
+    dx_tot = xt_hi - xt_lo
+    yt_lo = yt[indx_lo]
+    yt_hi = yt[indx_hi]
+    dy_tot = yt_hi - yt_lo
+    m = dy_tot / dx_tot
+    y = yt_lo + m * (x - xt_lo)
+    return y


### PR DESCRIPTION
In PR #4 the function **_gas_conversion_kern** was moved into a new `gas.py` module, and the **tw_bin_jax_kern** function was moved into `utils.py`, but #4 forgot to remove these functions from `stars.py`. This PR removes these functions from `stars.py` and so resolves this code duplication.

Separately, this PR migrates the function `jax_np_interp` into `utils.py`. Probably we should not be using this function anymore, since this is a relic of an era when JAX had not yet implemented `jnp.interp`. 