### PR TITLE
adding diffstar/kernels folder as a module that can be imported

### DIFF
--- a/diffstar/__init__.py
+++ b/diffstar/__init__.py
@@ -3,3 +3,4 @@
 # flake8: noqa
 
 from ._version import __version__
+from . import kernels

--- a/diffstar/kernels/__init__.py
+++ b/diffstar/kernels/__init__.py
@@ -1,0 +1,4 @@
+from . import sfr_kernels
+from . import gas_consumption
+from . import main_sequence_kernels
+from . import quenching_kernels

--- a/diffstar/kernels/__init__.py
+++ b/diffstar/kernels/__init__.py
@@ -1,3 +1,7 @@
+"""
+"""
+# flake8: noqa
+
 from . import sfr_kernels
 from . import gas_consumption
 from . import main_sequence_kernels


### PR DESCRIPTION
This pull requests adds the `diffstar/kernels` folder as a module that can also be imported using `import diffstar.kernels` or the submodules that it contains  `import diffstar.kernels.sfr_kernels`, so I can use them in `diffstarpop`.

I think we should be able to just merge this to the main branch, but please take a look @aphearin 