### PR TITLE
Migrate data-loading modules in scripts into new diffstar.data_loaders subpackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+diffstar/_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/diffstar/data_loaders/load_bpl.py
+++ b/diffstar/data_loaders/load_bpl.py
@@ -1,13 +1,15 @@
 """
 """
 import os
-import numpy as np
-import h5py
 from collections import OrderedDict
+
+import h5py
+import numpy as np
 from astropy.table import Table
-from diffstar.utils import _jax_get_dt_array
-from diffstar.stars import _get_bounded_sfr_params_vmap
-from diffstar.quenching import _get_bounded_q_params_vmap
+
+from ..quenching import _get_bounded_q_params_vmap
+from ..stars import _get_bounded_sfr_params_vmap
+from ..utils import _jax_get_dt_array
 
 LGT0 = 1.13980
 

--- a/diffstar/data_loaders/load_smah_data.py
+++ b/diffstar/data_loaders/load_smah_data.py
@@ -1,11 +1,12 @@
 """
 """
-import numpy as np
 import os
-import h5py
 import warnings
-from diffstar.utils import _get_dt_array
 
+import h5py
+import numpy as np
+
+from ..utils import _get_dt_array
 
 TASSO = "/Users/aphearin/work/DATA/diffmah_data"
 BEBOP = "/lcrc/project/halotools/diffmah_data"
@@ -17,22 +18,25 @@ H_MDPL = H_BPL
 
 
 def load_fit_mah(filename, data_drn=BEBOP):
-    """ Load the best fit diffmah parameter data.
+    """Load the best fit diffmah parameter data
 
     Parameters
     ----------
     filename : string
-        Name of the h5 file where the diffmah best fit parameters are stored.
+        Name of the h5 file where the diffmah best fit parameters are stored
+
     data_drn : string
-        Filepath where the Diffstar best-fit parameters are stored.
+        Filepath where the Diffstar best-fit parameters are stored
 
     Returns
     -------
     mah_fit_params:  ndarray of shape (n_gal, 4)
         Best fit parameters for each halo:
             (logtc, k, early_index, late_index)
+
     logmp:  ndarray of shape (n_gal, )
-        Base-10 logarithm of the present day peak halo mass.
+        Base-10 logarithm of the present day peak halo mass
+
     """
     fitting_data = dict()
 
@@ -76,21 +80,27 @@ def load_bolshoi_data(gal_type, data_drn=BEBOP):
             'cens': central galaxies
             'sats': satellite galaxies
             'orphans': orphan galaxies
+
     data_drn : string
         Filepath where the Diffstar best-fit parameters are stored.
 
     Returns
     -------
     halo_ids:  ndarray of shape (n_gal, )
-        IDs of the halos in the file.
+        IDs of the halos in the file
+
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h=1
+
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h=1
+
     bpl_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
+
     dt : ndarray of shape (n_times, )
         Cosmic time steps between each simulated snapshot in Gyr
+
     """
     basename = "bpl_diffmah_{}.npy".format(gal_type)
     fn = os.path.join(data_drn, basename)
@@ -128,21 +138,28 @@ def load_bolshoi_small_data(gal_type, data_drn=BEBOP):
             'cens': central galaxies
             'sats': satellite galaxies
             'orphans': orphan galaxies
+
     data_drn : string
         Filepath where the Diffstar best-fit parameters are stored.
 
     Returns
     -------
     halo_ids:  ndarray of shape (n_gal, )
-        IDs of the halos in the file.
+        IDs of the halos in the file
+
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h=1
+
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h=1
+
     bpl_t : ndarray of shape (n_times, )
+
         Cosmic time of each simulated snapshot in Gyr
+
     dt : ndarray of shape (n_times, )
         Cosmic time steps between each simulated snapshot in Gyr
+
     """
     basename = "um_histories_subsample_dr1_bpl_{}_diffmah.npy".format(gal_type)
     fn = os.path.join(data_drn, basename)
@@ -179,21 +196,27 @@ def load_tng_data(gal_type, data_drn=BEBOP):
             'cens': central galaxies
             'sats': satellite galaxies
             'orphans': orphan galaxies
+
     data_drn : string
         Filepath where the Diffstar best-fit parameters are stored.
 
     Returns
     -------
     halo_ids:  ndarray of shape (n_gal, )
-        IDs of the halos in the file.
+        IDs of the halos in the file
+
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h=1
+
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h=1
+
     tng_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
+
     dt : ndarray of shape (n_times, )
         Cosmic time steps between each simulated snapshot in Gyr
+
     """
     basename = "tng_diffmah.npy"
     fn = os.path.join(data_drn, basename)

--- a/notebooks/diffstar_fitter_demo.ipynb
+++ b/notebooks/diffstar_fitter_demo.ipynb
@@ -3,23 +3,17 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "c113bee8",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
-    "try:\n",
-    "    plt.rc('font', family=\"serif\")\n",
-    "    plt.rc('font', size=22)\n",
-    "    plt.rc('text', usetex=True)\n",
-    "    plt.rc('text.latex', preamble=r'\\usepackage{amsmath}') #necessary to use \\dfrac\n",
-    "except:\n",
-    "    pass\n"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "22adefc1",
    "metadata": {},
    "source": [
     "# Demonstration of how to fit halo MAHs with the `diffstar` model"
@@ -27,6 +21,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "14b6a060",
    "metadata": {},
    "source": [
     "This notebook illustrates a worked example of how to fit an individual halo SFH with the diffstar model. For a parallelized script, see `history_fitting_script.py`."
@@ -34,6 +29,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2133ec56",
    "metadata": {},
    "source": [
     "## Load a block of target data\n"
@@ -41,6 +37,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "407daea2",
    "metadata": {},
    "source": [
     "These data can be downloaded from the site hosting the project data. But in principle the fitting function should work with data from any sim."
@@ -49,6 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "590840f8",
    "metadata": {},
    "outputs": [
     {
@@ -61,25 +59,25 @@
     }
    ],
    "source": [
-    "import sys\n",
-    "sys.path.append('../scripts')\n",
-    "from load_smah_data import load_tng_data, load_fit_mah, LAPTOP \n"
+    "from diffstar.data_loaders.load_smah_data import load_tng_data, load_fit_mah, LAPTOP"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "cb9d84b1",
    "metadata": {},
    "outputs": [],
    "source": [
     "# This is the TNG simulation data.\n",
     "halo_ids, log_smahs, sfrhs, tarr, dt = load_tng_data(\"cens\", data_drn=LAPTOP)\n",
     "# This is the best-fit diffmah parameters fit to each TNG halo.\n",
-    "mah_fit_params, logmp = load_fit_mah(\"run1_tng_diffmah\", data_drn=LAPTOP)\n"
+    "mah_fit_params, logmp = load_fit_mah(\"run1_tng_diffmah\", data_drn=LAPTOP)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "c13bf819",
    "metadata": {},
    "source": [
     "## Pick a particular example galaxy history to fit\n"
@@ -88,6 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "65800317",
    "metadata": {},
    "outputs": [
     {
@@ -117,6 +116,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b468f0a",
    "metadata": {},
    "source": [
     "## Use L-BFGS-B to fit the SFH with the smooth model"
@@ -125,6 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
+   "id": "6d910114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,6 +141,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "44c8e2e2",
    "metadata": {},
    "source": [
     "## Grab the unbounded values of the best-fit parameters\n"
@@ -148,6 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
+   "id": "71ef0d2d",
    "metadata": {},
    "outputs": [
     {
@@ -192,6 +195,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02e77db7",
    "metadata": {},
    "source": [
     "## Transform the unbounded parameters to the actual `diffstar` parameters\n"
@@ -200,6 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
+   "id": "08eb60d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,11 +212,12 @@
     "from diffstar.quenching import _get_bounded_q_params\n",
     "\n",
     "sfr_fit_params = np.array(_get_bounded_sfr_params(*u_sfr_fit_params))\n",
-    "q_fit_params = np.array(_get_bounded_q_params(*u_q_fit_params))\n"
+    "q_fit_params = np.array(_get_bounded_q_params(*u_q_fit_params))"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d59a2918",
    "metadata": {},
    "source": [
     "## Calculate histories using the best-fit model\n"
@@ -220,6 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
+   "id": "89336a0b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,6 +252,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dc278a9c",
    "metadata": {},
    "source": [
     "## Compare the model to the simulated SFH\n"
@@ -253,6 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
+   "id": "4b7d145f",
    "metadata": {},
    "outputs": [
     {
@@ -296,6 +305,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dc49ae5b",
    "metadata": {},
    "source": [
     "## Show the model main sequence efficiency and quenching function"
@@ -304,6 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
+   "id": "670ad4c0",
    "metadata": {},
    "outputs": [
     {
@@ -351,6 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "97b3a90e",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -358,9 +370,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:diffit]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-diffit-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -372,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/scripts/generate_unit_testing_data.py
+++ b/scripts/generate_unit_testing_data.py
@@ -6,14 +6,18 @@ as the code evolves, then we will find out about it.
 """
 import argparse
 import os
-import numpy as np
-from diffstar.tests.test_diffstar_is_frozen import calc_sfh_on_default_params
-from diffstar.tests.test_diffstar_is_frozen import _get_default_mah_params
-from load_bpl import load_bpl_diffstar_data, TASSO_BPL_DRN, LGT0 as LGT0_BPL
-from diffmah.individual_halo_assembly import _calc_halo_history, DEFAULT_MAH_PARAMS
-from diffstar.stars import _sfr_history_from_mah
-from diffstar.utils import _jax_get_dt_array
 
+import numpy as np
+from diffmah.individual_halo_assembly import DEFAULT_MAH_PARAMS, _calc_halo_history
+
+from diffstar.data_loaders.load_bpl import LGT0 as LGT0_BPL
+from diffstar.data_loaders.load_bpl import TASSO_BPL_DRN, load_bpl_diffstar_data
+from diffstar.stars import _sfr_history_from_mah
+from diffstar.tests.test_diffstar_is_frozen import (
+    _get_default_mah_params,
+    calc_sfh_on_default_params,
+)
+from diffstar.utils import _jax_get_dt_array
 
 MAH_K = DEFAULT_MAH_PARAMS["mah_k"]
 
@@ -101,6 +105,10 @@ if __name__ == "__main__":
         os.path.join(testing_drn, "q_u_params_test_sample.txt"), q_u_params_test_sample
     )
     np.savetxt(
+        os.path.join(testing_drn, "halo_ids_test_sample.txt"), halo_ids_test_sample
+    )
+    np.savetxt(os.path.join(testing_drn, "lgt_bpl.txt"), lgt_bpl)
+    np.savetxt(os.path.join(testing_drn, "dt_bpl.txt"), dt_bpl)
         os.path.join(testing_drn, "halo_ids_test_sample.txt"), halo_ids_test_sample
     )
     np.savetxt(os.path.join(testing_drn, "lgt_bpl.txt"), lgt_bpl)

--- a/scripts/history_fitting_script.py
+++ b/scripts/history_fitting_script.py
@@ -1,61 +1,58 @@
 """Script to fit Bolshoi or Multidark MAHs with a smooth model."""
-import numpy as np
-import os
-from mpi4py import MPI
 import argparse
-from time import time
-from load_smah_data import (
-    TASSO,
-    BEBOP,
-    load_fit_mah,
-    load_bolshoi_data,
-    load_tng_data,
-    load_mdpl_data,
-    load_bolshoi_small_data,
-    load_tng_small_data,
-    load_mdpl_small_data,
-)
-
-from diffstar.fit_smah_helpers import get_header, MIN_MASS_CUT, SSFRH_FLOOR
-from diffstar.fit_smah_helpers import (
-    get_loss_data_default,
-    get_loss_data_free,
-    get_loss_data_fixed_noquench,
-    get_loss_data_fixed_hi,
-    get_loss_data_fixed_hi_rej,
-    get_loss_data_fixed_hi_depl,
-    get_loss_data_fixed_depl_noquench,
-)
-from diffstar.fit_smah_helpers import (
-    loss_default,
-    loss_free,
-    loss_fixed_noquench,
-    loss_fixed_hi,
-    loss_fixed_hi_rej,
-    loss_fixed_hi_depl,
-    loss_fixed_depl_noquench,
-    loss_grad_default_np,
-    loss_free_deriv_np,
-    loss_fixed_noquench_deriv_np,
-    loss_fixed_hi_deriv_np,
-    loss_fixed_hi_rej_deriv_np,
-    loss_fixed_hi_depl_deriv_np,
-    loss_fixed_depl_noquench_deriv_np,
-)
-from diffstar.fit_smah_helpers import (
-    get_outline_default,
-    get_outline_free,
-    get_outline_fixed_noquench,
-    get_outline_fixed_hi,
-    get_outline_fixed_hi_rej,
-    get_outline_fixed_hi_depl,
-    get_outline_fixed_depl_noquench,
-)
-
-from diffstar.utils import minimizer_wrapper
+import os
 import subprocess
-import h5py
+from time import time
 
+import h5py
+import numpy as np
+from mpi4py import MPI
+
+from diffstar.data_loaders.load_smah_data import (
+    BEBOP,
+    TASSO,
+    load_bolshoi_data,
+    load_bolshoi_small_data,
+    load_fit_mah,
+    load_mdpl_data,
+    load_mdpl_small_data,
+    load_tng_data,
+    load_tng_small_data,
+)
+from diffstar.fit_smah_helpers import (
+    MIN_MASS_CUT,
+    SSFRH_FLOOR,
+    get_header,
+    get_loss_data_default,
+    get_loss_data_fixed_depl_noquench,
+    get_loss_data_fixed_hi,
+    get_loss_data_fixed_hi_depl,
+    get_loss_data_fixed_hi_rej,
+    get_loss_data_fixed_noquench,
+    get_loss_data_free,
+    get_outline_default,
+    get_outline_fixed_depl_noquench,
+    get_outline_fixed_hi,
+    get_outline_fixed_hi_depl,
+    get_outline_fixed_hi_rej,
+    get_outline_fixed_noquench,
+    get_outline_free,
+    loss_default,
+    loss_fixed_depl_noquench,
+    loss_fixed_depl_noquench_deriv_np,
+    loss_fixed_hi,
+    loss_fixed_hi_depl,
+    loss_fixed_hi_depl_deriv_np,
+    loss_fixed_hi_deriv_np,
+    loss_fixed_hi_rej,
+    loss_fixed_hi_rej_deriv_np,
+    loss_fixed_noquench,
+    loss_fixed_noquench_deriv_np,
+    loss_free,
+    loss_free_deriv_np,
+    loss_grad_default_np,
+)
+from diffstar.utils import minimizer_wrapper
 
 TMP_OUTPAT = "_tmp_smah_fits_rank_{0}.dat"
 TODAY = 13.8
@@ -119,7 +116,10 @@ if __name__ == "__main__":
         default=MIN_MASS_CUT,
     )
     parser.add_argument(
-        "-ssfrh_floor", help="Clipping floor for sSFH", type=float, default=SSFRH_FLOOR,
+        "-ssfrh_floor",
+        help="Clipping floor for sSFH",
+        type=float,
+        default=SSFRH_FLOOR,
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
The functions implemented in the `load_smah_data.py` and `load_bpl.py` modules can now be imported after installing diffstar. I have modified the `diffstar_fitter_demo.ipynb` notebook to demo how this works:

`>>> from diffstar.data_loaders.load_smah_data import load_tng_data, load_fit_mah, LAPTOP`

I didn't touch the internals of these two modules but they are entirely without tests and so I have not rerun the notebook or the fitter script after making these changes.