### PR TITLE
Modify output column names of fitter to prepend u_ to unbounded parameters

### DIFF
--- a/diffstar/fit_smah_helpers.py
+++ b/diffstar/fit_smah_helpers.py
@@ -38,8 +38,8 @@ SSFRH_FLOOR = 1e-12  # Clip SFH to this minimum sSFR value. 1/yr units.
 def get_header():
     out = """\
 # halo_id \
-lgmcrit lgy_at_mcrit indx_lo indx_hi tau_dep \
-qt qs q_drop q_rejuv \
+u_lgmcrit u_lgy_at_mcrit u_indx_lo u_indx_hi u_tau_dep \
+u_qt u_qs u_q_drop u_q_rejuv \
 loss success\n\
 """
     return out


### PR DESCRIPTION
The module `fit_smah_helpers.py` writes the outputs of the diffstar fits to an hdf5 file. Previously, the output column names were things like `lgmcrit` and `lgy_at_mcrit` even though the fitter outputs unbounded parameters. This PR updates the `get_header` function so that the new column names will be things like `u_lgmcrit` and `u_lgy_at_mcrit`.