### PR TITLE
Rename quenching kernel to adopt u_params convention

### DIFF
--- a/diffstar/kernels/quenching_kernels.py
+++ b/diffstar/kernels/quenching_kernels.py
@@ -35,7 +35,7 @@ MS_BOUNDING_SIGMOID_PDICT = calculate_sigmoid_bounds(Q_PARAM_BOUNDS_PDICT)
 
 
 @jjit
-def quenching_function(lgt, u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv):
+def _quenching_kern_u_params(lgt, u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv):
     """Quenching function halting the star formation of main sequence galaxies.
 
     After some time, galaxies might experience a rejuvenated star formation.

--- a/diffstar/kernels/sfr_kernels.py
+++ b/diffstar/kernels/sfr_kernels.py
@@ -7,7 +7,7 @@ from jax import vmap
 
 from ..utils import jax_np_interp
 from .main_sequence_kernels import _ms_sfr_history_from_mah
-from .quenching_kernels import quenching_function
+from .quenching_kernels import _quenching_kern_u_params
 
 
 @jjit
@@ -300,6 +300,6 @@ def _sfr_history_from_mah(lgt, dtarr, dmhdt, log_mah, sfr_params, q_params):
 
     """
     ms_sfr = _ms_sfr_history_from_mah(lgt, dtarr, dmhdt, log_mah, sfr_params)
-    qfrac = quenching_function(lgt, *q_params)
+    qfrac = _quenching_kern_u_params(lgt, *q_params)
     sfr = qfrac * ms_sfr
     return sfr

--- a/diffstar/quenching.py
+++ b/diffstar/quenching.py
@@ -34,7 +34,7 @@ def quenching_function(lgt, u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv):
     History of the multiplicative change of SFR
 
     """
-    return qk.quenching_function(lgt, u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv)
+    return qk._quenching_kern_u_params(lgt, u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv)
 
 
 @jjit

--- a/diffstar/sfh.py
+++ b/diffstar/sfh.py
@@ -11,7 +11,7 @@ from .kernels.main_sequence_kernels import (
     _get_bounded_sfr_params,
     _lax_ms_sfh_scalar_kern,
 )
-from .kernels.quenching_kernels import quenching_function
+from .kernels.quenching_kernels import _quenching_kern_u_params
 
 
 def get_sfh_from_mah_kern(
@@ -69,7 +69,7 @@ def get_sfh_from_mah_kern(
         args = t_form, mah_params, ms_params, lgt0, fb, t_table
         ms_sfr = _lax_ms_sfh_scalar_kern(*args)
         lgt_form = jnp.log10(t_form)
-        qfunc = quenching_function(lgt_form, *u_q_params)
+        qfunc = _quenching_kern_u_params(lgt_form, *u_q_params)
         sfr = qfunc * ms_sfr
         return sfr
 

--- a/diffstar/tests/test_diffstar_is_frozen.py
+++ b/diffstar/tests/test_diffstar_is_frozen.py
@@ -10,8 +10,8 @@ from diffmah.individual_halo_assembly import (
 )
 from jax import numpy as jnp
 
-from ..defaults import DEFAULT_MS_PARAMS, DEFAULT_U_Q_PARAMS, LGT0
-from ..fitting_helpers.stars import _get_unbounded_sfr_params, _sfr_history_from_mah
+from ..defaults import DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS, LGT0
+from ..fitting_helpers.stars import _sfr_history_from_mah
 from ..kernels.quenching_kernels import _get_unbounded_q_params
 from ..utils import _get_dt_array
 
@@ -34,7 +34,7 @@ def _get_default_mah_params():
 
 
 def _get_default_sfr_u_params():
-    u_ms_params = jnp.array(_get_unbounded_sfr_params(*DEFAULT_MS_PARAMS))
+    u_ms_params = jnp.array(DEFAULT_U_MS_PARAMS)
     u_q_params = jnp.array(_get_unbounded_q_params(*DEFAULT_U_Q_PARAMS))
     return u_ms_params, u_q_params
 


### PR DESCRIPTION
This PR renames [diffstar.quenching.kernels.quenching_function](https://github.com/ArgonneCPAC/diffstar/blob/04197a6b818a133682b5e7090a1bd2bd150cab3f/diffstar/kernels/quenching_kernels.py#L38) to **_quenching_kern_u_params**. Note that this PR makes no changes to user-facing functions, only the kernels defined inside diffstar.kernels. Any other change (such as those to [sfh.py](https://github.com/ArgonneCPAC/diffstar/blob/04197a6b818a133682b5e7090a1bd2bd150cab3f/diffstar/sfh.py#L14) and [quenching.py](https://github.com/ArgonneCPAC/diffstar/blob/04197a6b818a133682b5e7090a1bd2bd150cab3f/diffstar/quenching.py#L37)) are only to update calls to the newly-named kernel.