### PR TITLE
Migrate test_diffstar_is_frozen.py into fitting_kernels

### DIFF
--- a/diffstar/fitting_helpers/tests/test_fitting_kernels_are_frozen.py
+++ b/diffstar/fitting_helpers/tests/test_fitting_kernels_are_frozen.py
@@ -10,15 +10,17 @@ from diffmah.individual_halo_assembly import (
 )
 from jax import numpy as jnp
 
-from ..defaults import DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS, LGT0
-from ..fitting_helpers.fitting_kernels import _sfr_history_from_mah
-from ..kernels.quenching_kernels import _get_unbounded_q_params
-from ..utils import _get_dt_array
+from ...defaults import DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS, LGT0
+from ...kernels.quenching_kernels import _get_unbounded_q_params
+from ...utils import _get_dt_array
+from ..fitting_kernels import _sfr_history_from_mah
 
 DEFAULT_LOGM0 = 12.0
 
 _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
-TESTING_DATA_DRN = os.path.join(_THIS_DRNAME, "testing_data")
+TESTING_DATA_DRN = os.path.join(
+    os.path.dirname(os.path.dirname(_THIS_DRNAME)), "tests", "testing_data"
+)
 
 
 def _get_default_mah_params():

--- a/diffstar/tests/test_gas.py
+++ b/diffstar/tests/test_gas.py
@@ -1,8 +1,10 @@
 """
 """
+from ..fitting_helpers.tests.test_fitting_kernels_are_frozen import (
+    calc_sfh_on_default_params,
+)
 from ..kernels.gas_consumption import _get_lagged_gas
 from ..kernels.main_sequence_kernels import MS_BOUNDING_SIGMOID_PDICT
-from .test_diffstar_is_frozen import calc_sfh_on_default_params
 
 
 def test_lagged_gas():

--- a/diffstar/tests/test_lax_main_sequence.py
+++ b/diffstar/tests/test_lax_main_sequence.py
@@ -5,13 +5,13 @@ from jax import jit as jjit
 from jax import vmap
 
 from ..defaults import FB, LGT0
-from ..kernels.kernel_builders import get_ms_sfh_from_mah_kern
-from ..kernels.quenching_kernels import _quenching_kern_u_params
-from .test_diffstar_is_frozen import (
+from ..fitting_helpers.tests.test_fitting_kernels_are_frozen import (
     _get_default_mah_params,
     _get_default_sfr_u_params,
     calc_sfh_on_default_params,
 )
+from ..kernels.kernel_builders import get_ms_sfh_from_mah_kern
+from ..kernels.quenching_kernels import _quenching_kern_u_params
 
 
 def _get_all_default_params():

--- a/diffstar/tests/test_lax_sfh.py
+++ b/diffstar/tests/test_lax_sfh.py
@@ -5,12 +5,12 @@ from jax import jit as jjit
 from jax import vmap
 
 from ..defaults import FB, LGT0
-from ..kernels.kernel_builders import get_sfh_from_mah_kern
-from .test_diffstar_is_frozen import (
+from ..fitting_helpers.tests.test_fitting_kernels_are_frozen import (
     _get_default_mah_params,
     _get_default_sfr_u_params,
     calc_sfh_on_default_params,
 )
+from ..kernels.kernel_builders import get_sfh_from_mah_kern
 
 
 def _get_all_default_params():

--- a/diffstar/tests/test_sfh.py
+++ b/diffstar/tests/test_sfh.py
@@ -4,8 +4,11 @@ import numpy as np
 
 from .. import sfh_galpop, sfh_singlegal
 from ..defaults import FB, LGT0, SFR_MIN
+from ..fitting_helpers.tests.test_fitting_kernels_are_frozen import (
+    _get_default_mah_params,
+    _get_default_sfr_u_params,
+)
 from ..kernels.kernel_builders import get_sfh_from_mah_kern
-from .test_diffstar_is_frozen import _get_default_mah_params, _get_default_sfr_u_params
 
 
 def _get_all_default_params():


### PR DESCRIPTION
No changes at all to functionality or testing beyond moving a testing module around, but this simplifies refactoring the kernels to be based on params rather than u_params