### PR TITLE
Add jitted control flow for unbounding parameter calculation

### DIFF
--- a/diffstar/sfh.py
+++ b/diffstar/sfh.py
@@ -1,9 +1,19 @@
 """
 """
+from functools import partial
+
 from jax import jit as jjit
 
 from .defaults import DEFAULT_N_STEPS, FB, LGT0, T_BIRTH_MIN
 from .kernels.kernel_builders import get_sfh_from_mah_kern
+from .kernels.main_sequence_kernels import (
+    _get_unbounded_sfr_params,
+    _get_unbounded_sfr_params_vmap,
+)
+from .kernels.quenching_kernels import (
+    _get_unbounded_q_params,
+    _get_unbounded_q_params_vmap,
+)
 
 _sfh_singlegal_kern = get_sfh_from_mah_kern(
     n_steps=DEFAULT_N_STEPS,
@@ -18,8 +28,17 @@ _sfh_galpop_kern = get_sfh_from_mah_kern(
 )
 
 
-@jjit
-def sfh_singlegal(tarr, mah_params, u_ms_params, u_q_params, lgt0=LGT0, fb=FB):
+@partial(jjit, static_argnames=["ms_param_type", "q_param_type"])
+def sfh_singlegal(
+    tarr,
+    mah_params,
+    u_ms_params,
+    u_q_params,
+    lgt0=LGT0,
+    fb=FB,
+    ms_param_type="unbounded",
+    q_param_type="unbounded",
+):
     """Calculate the star formation history of a single diffstar galaxy
 
     Parameters
@@ -30,7 +49,15 @@ def sfh_singlegal(tarr, mah_params, u_ms_params, u_q_params, lgt0=LGT0, fb=FB):
         mah_params = (lgm0, logtc, early_index, late_index)
 
     u_ms_params : ndarray, shape (5, )
-        u_ms_params = (u_lgmcrit, u_lgy_at_mcrit, u_indx_lo, u_indx_hi, u_tau_dep)
+        By default the input u_ms_params will be interpreted as the
+        unbounded versions of the standard diffstar params:
+            u_ms_params = (u_lgmcrit, u_lgy_at_mcrit, u_indx_lo, u_indx_hi, u_tau_dep)
+
+        However, if ms_param_type="bounded", then the input parameters parameters
+        will be interpreted as the standard diffstar params:
+            u_ms_params = (lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep)
+
+        See notes for further details
 
     u_q_params : ndarray, shape (4, )
         u_q_params = (u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv)
@@ -43,16 +70,51 @@ def sfh_singlegal(tarr, mah_params, u_ms_params, u_q_params, lgt0=LGT0, fb=FB):
         Cosmic baryon fraction
         Default value set by diffstar.defaults.FB
 
+    ms_param_type : bool, optional
+        Determines whether to interpret the input main sequence parameters as being
+        unbounded version of the diffstar params. Default is "unbounded".
+
+    q_param_type : bool, optional
+        Determines whether to interpret the input quenching parameters as being
+        unbounded version of the diffstar params. Default is "unbounded".
+
     Returns
     -------
     sfh : ndarray, shape (n_t, )
 
+    Notes
+    -----
+    The ms_param_type and q_param_type options allow you call sfh_singlegal
+    with input parameters that are either standard bounded parameters or unbounded ones.
+    By default, ms_param_type and q_param_type are "unbounded",
+    and so the input parameters can take on any value on the real line,
+    and as an input unbounded parameter varies between (-∞, ∞),
+    the corresponding diffstar parameter varies within its physically allowed range.
+    But if the param type is "bounded", then the input parameters will instead be
+    interpreted as the standard diffstar parameters; note that in this case,
+    the numerical value of each input parameters should line within the
+    physically allowed range, or else infinities and NaNs can result.
+
     """
+    if ms_param_type == "bounded":
+        u_ms_params = _get_unbounded_sfr_params(*u_ms_params)
+    if q_param_type == "bounded":
+        u_q_params = _get_unbounded_q_params(*u_q_params)
     return _sfh_singlegal_kern(tarr, mah_params, u_ms_params, u_q_params, lgt0, fb)
 
 
+@partial(jjit, static_argnames=["ms_param_type", "q_param_type"])
 @jjit
-def sfh_galpop(tarr, mah_params, u_ms_params, u_q_params, lgt0=LGT0, fb=FB):
+def sfh_galpop(
+    tarr,
+    mah_params,
+    u_ms_params,
+    u_q_params,
+    lgt0=LGT0,
+    fb=FB,
+    ms_param_type="unbounded",
+    q_param_type="unbounded",
+):
     """Calculate the star formation history of a diffstar galaxy population
 
     Parameters
@@ -63,11 +125,24 @@ def sfh_galpop(tarr, mah_params, u_ms_params, u_q_params, lgt0=LGT0, fb=FB):
         For each galaxy, mah_params = (lgm0, logtc, early_index, late_index)
 
     u_ms_params : ndarray, shape (n_gals, 5)
-        For each galaxy,
-        u_ms_params = (u_lgmcrit, u_lgy_at_mcrit, u_indx_lo, u_indx_hi, u_tau_dep)
+        For each galaxy, by default the input u_ms_params will be interpreted as the
+        unbounded versions of the standard diffstar params:
+            u_ms_params = (u_lgmcrit, u_lgy_at_mcrit, u_indx_lo, u_indx_hi, u_tau_dep)
+
+        However, if ms_param_type="bounded", then the input parameters parameters
+        will be interpreted as the standard diffstar params:
+            u_ms_params = (lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep)
+
+        See notes for further details
 
     u_q_params : ndarray, shape (n_gals, 4)
-        For each galaxy, u_q_params = (u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv)
+        For each galaxy, by default the input u_q_params will be interpreted as the
+        unbounded versions of the standard diffstar params:
+            u_q_params = (u_lg_qt, u_lg_qs, u_lg_drop, u_lg_rejuv)
+
+        However, if q_param_type="bounded", then the input parameters parameters
+        will be interpreted as the standard diffstar params:
+            u_q_params = (lg_qt, lg_qs, lg_drop, lg_rejuv)
 
     lgt0 : float, optional
         Base-10 log of the age of the universe in Gyr
@@ -77,9 +152,34 @@ def sfh_galpop(tarr, mah_params, u_ms_params, u_q_params, lgt0=LGT0, fb=FB):
         Cosmic baryon fraction
         Default value set by diffstar.defaults.FB
 
+    ms_param_type : bool, optional
+        Determines whether to interpret the input main sequence parameters as being
+        unbounded version of the diffstar params. Default is "unbounded".
+
+    q_param_type : bool, optional
+        Determines whether to interpret the input quenching parameters as being
+        unbounded version of the diffstar params. Default is "unbounded".
+
     Returns
     -------
     sfh : ndarray, shape (n_gals, n_t)
 
+    Notes
+    -----
+    The ms_param_type and q_param_type options allow you call sfh_singlegal
+    with input parameters that are either standard bounded parameters or unbounded ones.
+    By default, ms_param_type and q_param_type are "unbounded",
+    and so the input parameters can take on any value on the real line,
+    and as an input unbounded parameter varies between (-∞, ∞),
+    the corresponding diffstar parameter varies within its physically allowed range.
+    But if the param type is "bounded", then the input parameters will instead be
+    interpreted as the standard diffstar parameters; note that in this case,
+    the numerical value of each input parameters should line within the
+    physically allowed range, or else infinities and NaNs can result.
+
     """
+    if ms_param_type == "bounded":
+        u_ms_params = _get_unbounded_sfr_params_vmap(*u_ms_params)
+    if q_param_type == "bounded":
+        u_q_params = _get_unbounded_q_params_vmap(*u_q_params)
     return _sfh_galpop_kern(tarr, mah_params, u_ms_params, u_q_params, lgt0, fb)


### PR DESCRIPTION
The kernels `sfh_singlegal` and `sfh_galpop` now accept optional keyword arguments (`ms_param_type` and `q_param_type`), which allow you to specify whether you are inputting standard diffstar parameters or their unbounded counterparts. Including this option has a couple of advantages:
1. You call the same SFH kernel every time, whether you happen to have bounded or unbounded parameters on hand. 
2. So long as you know which version of the parameters you have on hand, you don't have to think about what bounding functions to call, you can just leave it up to the internals of the SFH kernel to handle calling the appropriate bounding functions as necessary.

The downside is that this is our core user-facing function, and a first-time user may find it annoying to have to learn/think about our parameter bounding technique when reading our long-ish docstring.

This PR does not change the current u_param convention, and so "unbounded" is the default option for these two `sfh_singlegal` and `sfh_galpop`. That will be changed in a separate PR.