### PR TITLE
Implement parameter clipping functions

### DIFF
--- a/diffstar/fitting_helpers/__init__.py
+++ b/diffstar/fitting_helpers/__init__.py
@@ -1,0 +1,4 @@
+"""
+"""
+# flake8: noqa
+from .param_clippers import ms_param_clipper, q_param_clipper

--- a/diffstar/fitting_helpers/param_clippers.py
+++ b/diffstar/fitting_helpers/param_clippers.py
@@ -1,0 +1,78 @@
+"""Functions ms_param_clipper and q_param_clipper implement clips on the diffstar
+parameters to help protect against NaNs and infinities
+"""
+from collections import OrderedDict
+
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from ..kernels.main_sequence_kernels import MS_PARAM_BOUNDS_PDICT
+from ..kernels.quenching_kernels import Q_PARAM_BOUNDS_PDICT
+
+_EPS = 0.001
+
+MS_CLIPPING_DICT = OrderedDict()
+Q_CLIPPING_DICT = OrderedDict()
+
+for key, bounds in MS_PARAM_BOUNDS_PDICT.items():
+    lo, hi = bounds
+    MS_CLIPPING_DICT[key] = (lo + _EPS, hi - _EPS)
+for key, bounds in Q_PARAM_BOUNDS_PDICT.items():
+    lo, hi = bounds
+    Q_CLIPPING_DICT[key] = (lo + _EPS, hi - _EPS)
+
+MS_CLIPS_LO = jnp.array([x[0] for x in MS_CLIPPING_DICT.values()])
+MS_CLIPS_HI = jnp.array([x[1] for x in MS_CLIPPING_DICT.values()])
+Q_CLIPS_LO = jnp.array([x[0] for x in Q_CLIPPING_DICT.values()])
+Q_CLIPS_HI = jnp.array([x[1] for x in Q_CLIPPING_DICT.values()])
+
+
+@jjit
+def _clipping_kern(arr, lo, hi):
+    msk_lo = arr <= lo
+    msk_hi = arr >= hi
+    arr = jnp.where(msk_lo, lo, arr)
+    arr = jnp.where(msk_hi, hi, arr)
+    return arr
+
+
+_clipping_kern_vmap = jjit(vmap(_clipping_kern, in_axes=(0, 0, 0)))
+
+
+@jjit
+def ms_param_clipper(ms_params):
+    """Clip the main sequence parameters to be at least epsilon away from the bounds
+
+    Parameters
+    ----------
+    ms_params : ndarray, shape (n, 5)
+
+    Returns
+    ----------
+    clipped_ms_params : ndarray, shape (n, 5)
+
+    """
+    clipped_ms_params = _clipping_kern_vmap(ms_params.T, MS_CLIPS_LO, MS_CLIPS_HI).T
+    return clipped_ms_params
+
+
+@jjit
+def q_param_clipper(q_params):
+    """Clip the quenching parameters to be at least epsilon away from the bounds
+
+    Parameters
+    ----------
+    q_params : ndarray, shape (n, 4)
+
+    Returns
+    ----------
+    clipped_q_params : ndarray, shape (n, 4)
+
+    """
+    clipped_q_params = _clipping_kern_vmap(q_params.T, Q_CLIPS_LO, Q_CLIPS_HI).T
+    rejuv_clip = clipped_q_params[:, 2] + _EPS / 2
+    msk_rejuv = clipped_q_params[:, 3] <= rejuv_clip
+    new_lg_rejuv = jnp.where(msk_rejuv, rejuv_clip, clipped_q_params[:, 3])
+    clipped_q_params = clipped_q_params.at[:, 3].set(new_lg_rejuv)
+    return clipped_q_params

--- a/diffstar/fitting_helpers/tests/test_param_clippers.py
+++ b/diffstar/fitting_helpers/tests/test_param_clippers.py
@@ -1,0 +1,71 @@
+"""
+"""
+import numpy as np
+from jax import random as jran
+
+from ...kernels.main_sequence_kernels import (
+    MS_PARAM_BOUNDS_PDICT,
+    _get_bounded_sfr_params_vmap,
+    _get_unbounded_sfr_params_vmap,
+)
+from ...kernels.quenching_kernels import (
+    Q_PARAM_BOUNDS_PDICT,
+    _get_bounded_q_params_vmap,
+    _get_unbounded_q_params_vmap,
+)
+from ..param_clippers import _EPS, ms_param_clipper, q_param_clipper
+
+
+def test_ms_param_clipper_implements_correct_bounding_behavior():
+    n_gals = 1_000
+    ran_key = jran.PRNGKey(0)
+    u_ms_params = 10 ** jran.uniform(ran_key, minval=-5, maxval=5, shape=(n_gals, 5))
+
+    ms_params = _get_bounded_sfr_params_vmap(u_ms_params)
+    assert np.all(np.isfinite(ms_params))
+
+    # Enforce that clipping is actually necessary for these inputs
+    unclipped_u_ms_params = _get_unbounded_sfr_params_vmap(ms_params)
+    assert not np.all(np.isfinite(unclipped_u_ms_params))
+
+    clipped_ms_params = ms_param_clipper(ms_params)
+    assert clipped_ms_params.shape == (n_gals, 5)
+    assert np.all(np.isfinite(clipped_ms_params))
+    assert np.allclose(ms_params, clipped_ms_params, atol=_EPS)
+
+    for ip, bounds in enumerate(MS_PARAM_BOUNDS_PDICT.values()):
+        lo, hi = bounds
+        assert np.all(clipped_ms_params[:, ip] > lo)
+        assert np.all(clipped_ms_params[:, ip] < hi)
+
+    clipped_u_ms_params = _get_unbounded_sfr_params_vmap(clipped_ms_params)
+    assert np.all(np.isfinite(clipped_u_ms_params))
+
+
+def test_q_param_clipper_implements_correct_bounding_behavior():
+    n_gals = 1_000
+    ran_key = jran.PRNGKey(0)
+    u_q_params = 10 ** jran.uniform(ran_key, minval=-5, maxval=5, shape=(n_gals, 4))
+
+    q_params = _get_bounded_q_params_vmap(u_q_params)
+    assert np.all(np.isfinite(q_params))
+
+    # Enforce that clipping is actually necessary for these inputs
+    unclipped_u_q_params = _get_unbounded_q_params_vmap(q_params)
+    assert not np.all(np.isfinite(unclipped_u_q_params))
+
+    clipped_q_params = q_param_clipper(q_params)
+    assert clipped_q_params.shape == (n_gals, 4)
+    assert np.all(np.isfinite(clipped_q_params))
+    assert np.allclose(q_params, clipped_q_params, atol=_EPS)
+
+    for ip, bounds in enumerate(Q_PARAM_BOUNDS_PDICT.values()):
+        lo, hi = bounds
+        assert np.all(clipped_q_params[:, ip] > lo)
+        assert np.all(clipped_q_params[:, ip] < hi)
+
+    assert np.all(clipped_q_params[:, 3] > clipped_q_params[:, 2])
+
+    clipped_u_q_params = _get_unbounded_q_params_vmap(clipped_q_params)
+    assert clipped_u_q_params.shape == (n_gals, 4)
+    assert np.all(np.isfinite(clipped_u_q_params[:, 3]))

--- a/diffstar/kernels/main_sequence_kernels.py
+++ b/diffstar/kernels/main_sequence_kernels.py
@@ -174,8 +174,22 @@ def _get_unbounded_sfr_params(
     return bounded_params
 
 
-_get_bounded_sfr_params_vmap = jjit(vmap(_get_bounded_sfr_params, (0,) * 5, 0))
-_get_unbounded_sfr_params_vmap = jjit(vmap(_get_unbounded_sfr_params, (0,) * 5, 0))
+@jjit
+def _get_bounded_sfr_params_galpop_kern(ms_params):
+    return jnp.array(_get_bounded_sfr_params(*ms_params))
+
+
+@jjit
+def _get_unbounded_sfr_params_galpop_kern(u_ms_params):
+    return jnp.array(_get_unbounded_sfr_params(*u_ms_params))
+
+
+_get_bounded_sfr_params_vmap = jjit(
+    vmap(_get_bounded_sfr_params_galpop_kern, in_axes=(0,))
+)
+_get_unbounded_sfr_params_vmap = jjit(
+    vmap(_get_unbounded_sfr_params_galpop_kern, in_axes=(0,))
+)
 
 
 DEFAULT_U_MS_PARAMS = _get_unbounded_sfr_params(*DEFAULT_MS_PARAMS)

--- a/diffstar/kernels/quenching_kernels.py
+++ b/diffstar/kernels/quenching_kernels.py
@@ -10,12 +10,12 @@ from jax import vmap
 from ..utils import _inverse_sigmoid, _sigmoid
 
 DEFAULT_Q_PDICT = OrderedDict(
-    u_lg_qt=1.0, u_lg_qs=-0.50725, u_lg_drop=-1.01773, u_lg_rejuv=-0.212307
+    lg_qt=1.0, qlglgdt=-0.50725, lg_drop=-1.01773, lg_rejuv=-0.212307
 )
 DEFAULT_Q_PARAMS = np.array(list(DEFAULT_Q_PDICT.values()))
 
 Q_PARAM_BOUNDS_PDICT = OrderedDict(
-    u_lg_qt=(0.1, 2.0), u_lg_qs=(-3.0, -0.01), u_lg_drop=(-3, 0.0), u_lg_rejuv=(-3, 0.0)
+    lg_qt=(0.1, 2.0), qlglgdt=(-3.0, -0.01), lg_drop=(-3, 0.0), lg_rejuv=(-3, 0.0)
 )
 
 
@@ -35,7 +35,7 @@ Q_BOUNDING_SIGMOID_PDICT = calculate_sigmoid_bounds(Q_PARAM_BOUNDS_PDICT)
 
 
 @jjit
-def _quenching_kern_u_params(lgt, u_lg_qt, u_lg_lg_q_dt, u_lg_drop, u_lg_rejuv):
+def _quenching_kern_u_params(lgt, u_lg_qt, u_qlglgdt, u_lg_drop, u_lg_rejuv):
     """Quenching function halting the star formation of main sequence galaxies.
 
     After some time, galaxies might experience a rejuvenated star formation.
@@ -49,7 +49,7 @@ def _quenching_kern_u_params(lgt, u_lg_qt, u_lg_lg_q_dt, u_lg_drop, u_lg_rejuv):
         Unbounded base-10 log of the time at which the quenching event bottoms out,
         i.e., the center of the event, in Gyr units.
 
-    u_lg_lg_q_dt : float
+    u_qlglgdt : float
         Unbounded value of log10(log10(q_dt))
         Controls duration of quenching event
 
@@ -64,10 +64,10 @@ def _quenching_kern_u_params(lgt, u_lg_qt, u_lg_lg_q_dt, u_lg_drop, u_lg_rejuv):
     History of the multiplicative change of SFR
 
     """
-    lg_qt, lg_lg_q_dt, lg_drop, lg_rejuv = _get_bounded_q_params(
-        u_lg_qt, u_lg_lg_q_dt, u_lg_drop, u_lg_rejuv
+    lg_qt, qlglgdt, lg_drop, lg_rejuv = _get_bounded_q_params(
+        u_lg_qt, u_qlglgdt, u_lg_drop, u_lg_rejuv
     )
-    lg_q_dt = 10**lg_lg_q_dt
+    lg_q_dt = 10**qlglgdt
     _bound_params = (lg_qt, lg_q_dt, lg_drop, lg_rejuv)
     return 10 ** _quenching_kern(lgt, *_bound_params)
 
@@ -99,7 +99,7 @@ def _quenching_kern(lgt, lg_qt, lg_q_dt, q_drop, q_rejuv):
 
     Returns
     -------
-    History of the base-10 logarithmic change in SFR
+    History of the multiplicative change of SFR
 
     """
     lg_q_dt_by_12 = lg_q_dt / 12  # account for 6σ width of two successive triweights
@@ -137,23 +137,23 @@ def _jax_partial_u_tw_kern(x, m, h, f1, f2):
 
 
 @jjit
-def _get_bounded_q_params(u_lg_qt, u_lg_lg_q_dt, u_lg_drop, u_lg_rejuv):
-    lg_qt = _sigmoid(u_lg_qt, *Q_BOUNDING_SIGMOID_PDICT["u_lg_qt"])
-    lg_lg_q_dt = _sigmoid(u_lg_lg_q_dt, *Q_BOUNDING_SIGMOID_PDICT["u_lg_qs"])
-    lg_drop = _sigmoid(u_lg_drop, *Q_BOUNDING_SIGMOID_PDICT["u_lg_drop"])
+def _get_bounded_q_params(u_lg_qt, u_qlglgdt, u_lg_drop, u_lg_rejuv):
+    lg_qt = _sigmoid(u_lg_qt, *Q_BOUNDING_SIGMOID_PDICT["lg_qt"])
+    qlglgdt = _sigmoid(u_qlglgdt, *Q_BOUNDING_SIGMOID_PDICT["qlglgdt"])
+    lg_drop = _sigmoid(u_lg_drop, *Q_BOUNDING_SIGMOID_PDICT["lg_drop"])
     lg_rejuv = _get_bounded_lg_rejuv(u_lg_rejuv, lg_drop)
-    return lg_qt, lg_lg_q_dt, lg_drop, lg_rejuv
+    return lg_qt, qlglgdt, lg_drop, lg_rejuv
 
 
 @jjit
 def _get_bounded_lg_drop(u_lg_drop):
-    lg_drop = _sigmoid(u_lg_drop, *Q_BOUNDING_SIGMOID_PDICT["u_lg_drop"])
+    lg_drop = _sigmoid(u_lg_drop, *Q_BOUNDING_SIGMOID_PDICT["lg_drop"])
     return lg_drop
 
 
 @jjit
 def _get_unbounded_lg_drop(lg_drop):
-    u_lg_drop = _inverse_sigmoid(lg_drop, *Q_BOUNDING_SIGMOID_PDICT["u_lg_drop"])
+    u_lg_drop = _inverse_sigmoid(lg_drop, *Q_BOUNDING_SIGMOID_PDICT["lg_drop"])
     return u_lg_drop
 
 
@@ -161,41 +161,53 @@ def _get_unbounded_lg_drop(lg_drop):
 def _get_bounded_lg_rejuv(u_lg_rejuv, lg_drop):
     lg_rejuv = _sigmoid(
         u_lg_rejuv,
-        *Q_BOUNDING_SIGMOID_PDICT["u_lg_rejuv"][:2],
+        *Q_BOUNDING_SIGMOID_PDICT["lg_rejuv"][:2],
         lg_drop,
-        Q_BOUNDING_SIGMOID_PDICT["u_lg_rejuv"][3],
+        Q_BOUNDING_SIGMOID_PDICT["lg_rejuv"][3],
     )
     return lg_rejuv
 
 
 @jjit
 def _get_bounded_qt(u_lg_qt):
-    lg_qt = _sigmoid(u_lg_qt, *Q_BOUNDING_SIGMOID_PDICT["u_lg_qt"])
+    lg_qt = _sigmoid(u_lg_qt, *Q_BOUNDING_SIGMOID_PDICT["lg_qt"])
     return lg_qt
 
 
 @jjit
-def _get_unbounded_q_params(lg_qt, lg_lg_q_dt, lg_drop, lg_rejuv):
-    u_lg_qt = _inverse_sigmoid(lg_qt, *Q_BOUNDING_SIGMOID_PDICT["u_lg_qt"])
-    u_lg_lg_q_dt = _inverse_sigmoid(lg_lg_q_dt, *Q_BOUNDING_SIGMOID_PDICT["u_lg_qs"])
-    u_lg_drop = _inverse_sigmoid(lg_drop, *Q_BOUNDING_SIGMOID_PDICT["u_lg_drop"])
+def _get_unbounded_q_params(lg_qt, qlglgdt, lg_drop, lg_rejuv):
+    u_lg_qt = _inverse_sigmoid(lg_qt, *Q_BOUNDING_SIGMOID_PDICT["lg_qt"])
+    u_qlglgdt = _inverse_sigmoid(qlglgdt, *Q_BOUNDING_SIGMOID_PDICT["qlglgdt"])
+    u_lg_drop = _inverse_sigmoid(lg_drop, *Q_BOUNDING_SIGMOID_PDICT["lg_drop"])
     u_lg_rejuv = _get_unbounded_qrejuv(lg_rejuv, lg_drop)
-    return u_lg_qt, u_lg_lg_q_dt, u_lg_drop, u_lg_rejuv
-
-
-_get_bounded_q_params_vmap = jjit(vmap(_get_bounded_q_params, (0,) * 4, 0))
-_get_unbounded_q_params_vmap = jjit(vmap(_get_unbounded_q_params, (0,) * 4, 0))
+    return u_lg_qt, u_qlglgdt, u_lg_drop, u_lg_rejuv
 
 
 @jjit
 def _get_unbounded_qrejuv(lg_rejuv, lg_drop):
     u_lg_rejuv = _inverse_sigmoid(
         lg_rejuv,
-        *Q_BOUNDING_SIGMOID_PDICT["u_lg_rejuv"][:2],
+        *Q_BOUNDING_SIGMOID_PDICT["lg_rejuv"][:2],
         lg_drop,
-        Q_BOUNDING_SIGMOID_PDICT["u_lg_rejuv"][3],
+        Q_BOUNDING_SIGMOID_PDICT["lg_rejuv"][3],
     )
     return u_lg_rejuv
+
+
+@jjit
+def _get_bounded_q_params_galpop_kern(q_params):
+    return jnp.array(_get_bounded_q_params(*q_params))
+
+
+@jjit
+def _get_unbounded_q_params_galpop_kern(u_q_params):
+    return jnp.array(_get_unbounded_q_params(*u_q_params))
+
+
+_get_bounded_q_params_vmap = jjit(vmap(_get_bounded_q_params_galpop_kern, in_axes=(0,)))
+_get_unbounded_q_params_vmap = jjit(
+    vmap(_get_unbounded_q_params_galpop_kern, in_axes=(0,))
+)
 
 
 DEFAULT_U_Q_PARAMS = _get_unbounded_q_params(*DEFAULT_Q_PARAMS)


### PR DESCRIPTION
New functions `ms_param_clipper` and `q_param_clipper` implement clips on the diffstar parameters to help protect against infinities and NaNs when the fitter runs up against the bounds.