### PR TITLE
Bring diffstar up-to-date with diffmah parameter changes

### DIFF
--- a/.github/workflows/test_releases.yml
+++ b/.github/workflows/test_releases.yml
@@ -31,7 +31,7 @@ jobs:
           use-mamba: true
 
       - name: configure conda and install code
-      # Test against current release of diffmah
+      # Test against current PyPi release of diffmah
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
@@ -47,6 +47,8 @@ jobs:
             setuptools \
             "setuptools_scm>=7,<8" \
             python-build
+          pip uninstall diffmah --yes
+          pip install --no-deps diffmah
           python -m pip install --no-build-isolation --no-deps -e .
 
       - name: test

--- a/diffstar/fitting_helpers/tests/test_fitting_kernels.py
+++ b/diffstar/fitting_helpers/tests/test_fitting_kernels.py
@@ -1,11 +1,8 @@
 """
 """
 import numpy as np
-from diffmah.individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
-    _calc_halo_history,
-    _get_early_late,
-)
+from diffmah.defaults import DEFAULT_MAH_PARAMS, MAH_K
+from diffmah.individual_halo_assembly import _calc_halo_history
 
 from ...defaults import DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS, FB, LGT0
 from ...kernels import get_sfh_from_mah_kern
@@ -22,12 +19,14 @@ DEFAULT_LOGM0 = 12.0
 
 
 def _get_default_diffmah_args():
-    mah_logtc, mah_k, mah_ue, mah_ul = list(DEFAULT_MAH_PARAMS.values())
-    early_index, late_index = _get_early_late(mah_ue, mah_ul)
-    k = DEFAULT_MAH_PARAMS["mah_k"]
-    logmp = DEFAULT_LOGM0
-    diffmah_args = [LGT0, logmp, mah_logtc, k, early_index, late_index]
-    return diffmah_args
+    return (
+        LGT0,
+        DEFAULT_MAH_PARAMS.logmp,
+        DEFAULT_MAH_PARAMS.logtc,
+        MAH_K,
+        DEFAULT_MAH_PARAMS.early_index,
+        DEFAULT_MAH_PARAMS.late_index,
+    )
 
 
 def test_calculate_sm_sfr_fstar_history_from_mah():

--- a/diffstar/fitting_helpers/tests/test_fitting_kernels_are_frozen.py
+++ b/diffstar/fitting_helpers/tests/test_fitting_kernels_are_frozen.py
@@ -3,11 +3,8 @@
 import os
 
 import numpy as np
-from diffmah.individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
-    _calc_halo_history,
-    _get_early_late,
-)
+from diffmah.defaults import DEFAULT_MAH_PARAMS, MAH_K
+from diffmah.individual_halo_assembly import _calc_halo_history
 from jax import numpy as jnp
 
 from ...defaults import DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS, LGT0
@@ -24,14 +21,14 @@ TESTING_DATA_DRN = os.path.join(
 
 def _get_default_mah_params():
     """Return (logt0, logmp, logtc, k, early, late)"""
-    mah_logtc, mah_k, mah_ue, mah_ul = list(DEFAULT_MAH_PARAMS.values())
-    early_index, late_index = _get_early_late(mah_ue, mah_ul)
-    k = DEFAULT_MAH_PARAMS["mah_k"]
-    logmp = DEFAULT_LOGM0
-
-    default_mah_params = [LGT0, logmp, mah_logtc, k, early_index, late_index]
-    default_mah_params = jnp.array(default_mah_params)
-    return default_mah_params
+    return (
+        LGT0,
+        DEFAULT_MAH_PARAMS.logmp,
+        DEFAULT_MAH_PARAMS.logtc,
+        MAH_K,
+        DEFAULT_MAH_PARAMS.early_index,
+        DEFAULT_MAH_PARAMS.late_index,
+    )
 
 
 def _get_default_sfr_u_params():
@@ -133,7 +130,7 @@ def test_diffmah_behavior_is_frozen():
     assert logmp == DEFAULT_LOGM0, msg
 
     msg = "Default mah_k parameter within Diffmah has changed"
-    assert DEFAULT_MAH_PARAMS["mah_k"] == 3.5, msg
+    assert MAH_K == 3.5, msg
 
     msg = "mah_k parameter returned by _get_default_mah_params function has changed"
     assert k == 3.5, msg
@@ -185,7 +182,7 @@ def test_sfh_is_frozen_on_example_bpl_sample():
                 LGT0_BPL,
                 mah_params_test_sample[ih, 0],
                 mah_params_test_sample[ih, 1],
-                DEFAULT_MAH_PARAMS["mah_k"],
+                MAH_K,
                 mah_params_test_sample[ih, 2],
                 mah_params_test_sample[ih, 3],
             )

--- a/diffstar/kernels/main_sequence_kernels.py
+++ b/diffstar/kernels/main_sequence_kernels.py
@@ -3,8 +3,8 @@
 from collections import OrderedDict, namedtuple
 
 import numpy as np
+from diffmah.defaults import MAH_K
 from diffmah.individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
     _calc_halo_history_scalar,
     _rolling_plaw_vs_logt,
 )
@@ -54,9 +54,8 @@ MS_BOUNDING_SIGMOID_PDICT = calculate_sigmoid_bounds(MS_PARAM_BOUNDS_PDICT)
 
 @jjit
 def _lax_ms_sfh_scalar_kern(t_form, mah_params, ms_params, lgt0, fb, t_table):
-    mah_k = DEFAULT_MAH_PARAMS["mah_k"]
     logmp, logtc, early, late = mah_params
-    all_mah_params = lgt0, logmp, logtc, mah_k, early, late
+    all_mah_params = lgt0, logmp, logtc, MAH_K, early, late
     lgt_form = jnp.log10(t_form)
     log_mah_at_tform = _rolling_plaw_vs_logt(lgt_form, *all_mah_params)
 

--- a/diffstar/tests/test_gas.py
+++ b/diffstar/tests/test_gas.py
@@ -1,11 +1,8 @@
 """
 """
 import numpy as np
-from diffmah.individual_halo_assembly import (
-    DEFAULT_MAH_PARAMS,
-    _calc_halo_history,
-    _get_early_late,
-)
+from diffmah.defaults import DEFAULT_MAH_PARAMS, MAH_K
+from diffmah.individual_halo_assembly import _calc_halo_history
 
 from ..defaults import DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS, LGT0
 from ..kernels.gas_consumption import _get_lagged_gas
@@ -18,11 +15,14 @@ DEFAULT_LOGM0 = 12.0
 
 def _get_default_mah_params():
     """Return (logt0, logmp, logtc, k, early, late)"""
-    mah_logtc, __, mah_ue, mah_ul = list(DEFAULT_MAH_PARAMS.values())
-    early_index, late_index = _get_early_late(mah_ue, mah_ul)
-    logmp = DEFAULT_LOGM0
-    k = DEFAULT_MAH_PARAMS["mah_k"]
-    return LGT0, logmp, mah_logtc, k, early_index, late_index
+    return (
+        LGT0,
+        DEFAULT_MAH_PARAMS.logmp,
+        DEFAULT_MAH_PARAMS.logtc,
+        MAH_K,
+        DEFAULT_MAH_PARAMS.early_index,
+        DEFAULT_MAH_PARAMS.late_index,
+    )
 
 
 def test_lagged_gas():


### PR DESCRIPTION
Bring diffstar up-to-date with `diffmah v0.5.0` parameter changes https://github.com/ArgonneCPAC/diffmah/pull/113. Mostly this amounts to doing this:
`
from diffmah.defaults import MAH_K
`
instead of `DEFAULT_MAH_PARAMS["mah_k"]`