### PR TITLE
Restore release testing against conda-forge

### DIFF
--- a/.github/workflows/test_releases.yml
+++ b/.github/workflows/test_releases.yml
@@ -31,7 +31,7 @@ jobs:
           use-mamba: true
 
       - name: configure conda and install code
-      # Test against current PyPi release of diffmah
+      # Test against current confa-forge release of diffmah
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
@@ -47,8 +47,6 @@ jobs:
             setuptools \
             "setuptools_scm>=7,<8" \
             python-build
-          pip uninstall diffmah --yes
-          pip install --no-deps diffmah
           python -m pip install --no-build-isolation --no-deps -e .
 
       - name: test

--- a/docs/source/rtd_environment.yaml
+++ b/docs/source/rtd_environment.yaml
@@ -14,5 +14,5 @@ dependencies:
   - numpy
   - jax
   - jaxlib
-  - diffmah
+  - diffmah>=0.5.0
   - h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffmah
+diffmah>=0.5.0
 numpy
 jax
 h5py


### PR DESCRIPTION
Require diffmah>=0.5.0 for next diffstar release