### PR TITLE
Add cumtrapz to diffstar.utils

### DIFF
--- a/.github/workflows/tests_cron.yml
+++ b/.github/workflows/tests_cron.yml
@@ -31,7 +31,7 @@ jobs:
           use-mamba: true
 
       - name: configure conda and install code
-      # Test against current main branch of diffmah
+      # Test against current main branch of diffmah and dsps
         shell: bash -l {0}
         run: |
           conda config --set always_yes yes
@@ -49,6 +49,7 @@ jobs:
             python-build
           pip uninstall diffmah --yes
           pip install --no-deps git+https://github.com/ArgonneCPAC/diffmah.git
+          pip install --no-deps git+https://github.com/ArgonneCPAC/dsps.git
           python -m pip install --no-build-isolation --no-deps -e .
 
       - name: test

--- a/diffstar/defaults.py
+++ b/diffstar/defaults.py
@@ -14,6 +14,7 @@ LGT0 = np.log10(TODAY)
 # Constants related to SFH integrals
 SFR_MIN = 1e-14
 T_BIRTH_MIN = 0.001
+T_TABLE_MIN = 0.01
 N_T_LGSM_INTEGRATION = 100
 DEFAULT_N_STEPS = 50
 

--- a/diffstar/tests/test_defaults.py
+++ b/diffstar/tests/test_defaults.py
@@ -1,6 +1,7 @@
 """
 """
 import numpy as np
+import pytest
 
 from .. import defaults
 from ..kernels.main_sequence_kernels import (
@@ -17,6 +18,15 @@ from ..kernels.quenching_kernels import (
     _quenching_kern,
     _quenching_kern_u_params,
 )
+
+try:
+    import dsps
+
+    HAS_DSPS = True
+except ImportError:
+    HAS_DSPS = False
+
+MSG_HAS_DSPS = "Must have dsps installed to run this test"
 
 
 def test_get_bounded_diffstar_params_return_unbounded_namedtuple():
@@ -201,3 +211,19 @@ def test_default_q_params_unquenched():
     assert np.all(res2 > 0.99)
 
     assert np.allclose(res, res2)
+
+
+@pytest.mark.skipif(not HAS_DSPS, reason=MSG_HAS_DSPS)
+def test_consistency_with_dsps_defaults():
+    assert np.allclose(defaults.SFR_MIN, dsps.constants.SFR_MIN)
+    assert np.allclose(defaults.T_BIRTH_MIN, dsps.constants.T_BIRTH_MIN)
+    assert np.allclose(defaults.T_TABLE_MIN, dsps.constants.T_TABLE_MIN)
+    assert np.allclose(
+        defaults.N_T_LGSM_INTEGRATION, dsps.constants.N_T_LGSM_INTEGRATION
+    )
+
+
+def test_consistency_with_diffmah_defaults():
+    from diffmah import defaults as diffmah_defaults
+
+    assert np.allclose(defaults.LGT0, diffmah_defaults.LGT0)

--- a/diffstar/tests/test_utils.py
+++ b/diffstar/tests/test_utils.py
@@ -1,9 +1,20 @@
 """
 """
 import numpy as np
+import pytest
 from jax import random as jran
 
-from ..utils import _get_dt_array, _jax_get_dt_array
+from ..defaults import T_TABLE_MIN
+from ..utils import _get_dt_array, _jax_get_dt_array, cumtrapz, cumulative_mstar_formed
+
+try:
+    import dsps
+
+    HAS_DSPS = True
+except ImportError:
+    HAS_DSPS = False
+
+MSG_HAS_DSPS = "Must have dsps installed to run this test"
 
 
 def test_jax_get_dt_array_linspace():
@@ -22,3 +33,40 @@ def test_jax_get_dt_array_random():
         dtarr_np = _get_dt_array(tarr)
         dtarr_jnp = _jax_get_dt_array(tarr)
         assert np.allclose(dtarr_np, dtarr_jnp, atol=0.01)
+
+
+def test_cumtrapz():
+    ran_key = jran.PRNGKey(0)
+    n_x = 100
+    n_tests = 10
+    for __ in range(n_tests):
+        x_key, y_key, ran_key = jran.split(ran_key, 3)
+        xarr = np.sort(jran.uniform(x_key, minval=0, maxval=1, shape=(n_x,)))
+        yarr = jran.uniform(y_key, minval=0, maxval=1, shape=(n_x,))
+        jax_result = cumtrapz(xarr, yarr)
+        np_result = [np.trapz(yarr[:-i], x=xarr[:-i]) for i in range(1, n_x)][::-1]
+        assert np.allclose(jax_result[:-1], np_result, rtol=1e-4)
+        assert np.allclose(jax_result[-1], np.trapz(yarr, x=xarr), rtol=1e-4)
+
+
+def test_cumulative_mstar_formed_returns_reasonable_arrays():
+    t_table = np.linspace(T_TABLE_MIN, 13.8, 200)
+    sfh_table = np.random.uniform(0, 1, t_table.size)
+    smh_table = cumulative_mstar_formed(t_table, sfh_table)
+    assert smh_table.shape == t_table.shape
+    assert np.all(smh_table > 0)
+    assert np.all(np.diff(smh_table) > 0)
+
+
+@pytest.mark.skipif(not HAS_DSPS, reason=MSG_HAS_DSPS)
+def test_cumulative_mstar_formed_agrees_with_dsps():
+    nt = 200
+    t_table = np.linspace(T_TABLE_MIN, 13.8, nt)
+    ran_key = jran.PRNGKey(0)
+    n_tests = 10
+    ran_keys = jran.split(ran_key, n_tests)
+    for key in ran_keys:
+        sfh_table = jran.uniform(key, minval=0, maxval=1, shape=(nt,))
+        smh_table_diffstar = cumulative_mstar_formed(t_table, sfh_table)
+        smh_table_dsps = dsps.utils.cumulative_mstar_formed(t_table, sfh_table)
+        assert np.allclose(smh_table_diffstar, smh_table_dsps, rtol=1e-4)

--- a/diffstar/utils.py
+++ b/diffstar/utils.py
@@ -4,6 +4,11 @@ import numpy as np
 from jax import jit as jjit
 from jax import lax
 from jax import numpy as jnp
+from jax.lax import scan
+
+from .defaults import SFR_MIN, T_BIRTH_MIN
+
+YEAR_PER_GYR = 1e9
 
 
 @jjit
@@ -195,3 +200,75 @@ def jax_np_interp(x, xt, yt, indx_hi):
     m = dy_tot / dx_tot
     y = yt_lo + m * (x - xt_lo)
     return y
+
+
+@jjit
+def _cumtrapz_scan_func(carryover, el):
+    b, fb = el
+    a, fa, cumtrapz = carryover
+    cumtrapz = cumtrapz + (b - a) * (fb + fa) / 2.0
+    carryover = b, fb, cumtrapz
+    accumulated = cumtrapz
+    return carryover, accumulated
+
+
+@jjit
+def cumtrapz(xarr, yarr):
+    """Cumulative trapezoidal integral
+
+    Parameters
+    ----------
+    xarr : ndarray, shape (n, )
+
+    yarr : ndarray, shape (n, )
+
+    Returns
+    -------
+    result : ndarray, shape (n, )
+
+    """
+    res_init = xarr[0], yarr[0], 0.0
+    scan_data = xarr, yarr
+    cumtrapz = scan(_cumtrapz_scan_func, res_init, scan_data)[1]
+    return cumtrapz
+
+
+@jjit
+def cumulative_mstar_formed(t_table, sfh_table):
+    """Compute the cumulative stellar mass formed at each input time
+
+    Parameters
+    ----------
+    t_table : ndarray, shape (n, )
+        Age of the Universe in Gyr.
+        Array should be monotonically increasing and
+        t_table[0] >= dsps.constants.T_TABLE_MIN
+
+    sfh_table : ndarray, shape (n, )
+        SFR in Msun/yr at each of the input times
+
+    Returns
+    -------
+    mstar_formed : ndarray, shape (n, )
+        Cumulative stellar mass formed in Msun at each input time
+
+    Notes
+    -----
+    Mstar formed is calculated using trapezoidal integration
+    and assuming that during the interval (dsps.constants.T_BIRTH_MIN, t_table[0]),
+    SFH is constant and equal to dsps.constants.SFR_MIN
+
+    """
+    n_t = t_table.size
+
+    padded_t_table = jnp.zeros(n_t + 1)
+    padded_t_table = padded_t_table.at[0].set(T_BIRTH_MIN)
+    padded_t_table = padded_t_table.at[1:].set(t_table)
+
+    padded_sfh_table = jnp.zeros(n_t + 1)
+    padded_sfh_table = padded_sfh_table.at[0].set(SFR_MIN)
+    padded_sfh_table = padded_sfh_table.at[1:].set(sfh_table)
+
+    mstar_formed = cumtrapz(padded_t_table, padded_sfh_table)[1:] * YEAR_PER_GYR
+
+    return mstar_formed


### PR DESCRIPTION
The cumtrapz function is a more accurate kernel to use when integrating SFH in comparison to previous calculations based on jax_get_dt_array. This PR implements the cumulative_mstar_formed function based on cumtrapz. This function has already been implemented in dsps, and so new unit tests enforce consistency with the same calculation within dsps.

@alexalar 