### PR TITLE
Add new convenience kernel for t_peak-based models

### DIFF
--- a/diffstar/sfh_model_tpeak.py
+++ b/diffstar/sfh_model_tpeak.py
@@ -1,0 +1,140 @@
+"""
+"""
+
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import vmap
+
+from .defaults import DEFAULT_N_STEPS, FB, LGT0, T_BIRTH_MIN
+from .kernels.history_kernel_builders import build_sfh_from_mah_kernel
+from .utils import cumulative_mstar_formed
+
+_sfh_singlegal_kern = build_sfh_from_mah_kernel(
+    n_steps=DEFAULT_N_STEPS,
+    tacc_integration_min=T_BIRTH_MIN,
+    tobs_loop="scan",
+    tform_loop="sum",
+)
+
+_sfh_galpop_kern = build_sfh_from_mah_kernel(
+    n_steps=DEFAULT_N_STEPS,
+    tacc_integration_min=T_BIRTH_MIN,
+    tobs_loop="scan",
+    galpop_loop="vmap",
+    tform_loop="sum",
+)
+
+_cumulative_mstar_formed_vmap = jjit(vmap(cumulative_mstar_formed, in_axes=(None, 0)))
+
+GalHistory = namedtuple("GalHistory", ("sfh", "smh"))
+
+
+@partial(jjit, static_argnames="return_smh")
+def calc_sfh_singlegal(
+    sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB, return_smh=False
+):
+    """Calculate the Diffstar SFH for a single galaxy
+
+    Parameters
+    ----------
+    sfh_params : namedtuple, length 2
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+
+    mah_params : namedtuple, length 4
+        mah_params is a tuple of floats
+        DiffmahParams = logmp, logtc, early_index, late_index
+
+    tarr : ndarray, shape (nt, )
+
+    lgt0 : float, optional
+        Base-10 log of the z=0 age of the Universe in Gyr
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    fb : float, optional
+        Cosmic baryon fraction Ob0/Om0
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    return_smh : bool, optional
+        If True, function return sfh, smh,
+        where smh is the history of stellar mass formed in units of Msun
+        Default is False, in which case function only returns sfh
+
+    Returns
+    -------
+    sfh : ndarray, shape (nt, )
+        Star formation rate in units of Msun/yr
+
+    smh : ndarray, shape (nt, ), optional
+        Stellar mass in units of Msun
+        This variable is only returned if return_smh=True
+
+    """
+    ms_params, q_params = sfh_params
+    args = (tarr, *mah_params, *ms_params, *q_params, lgt0, fb)
+    sfh = _sfh_singlegal_kern(*args)
+    if return_smh:
+        smh = cumulative_mstar_formed(tarr, sfh)
+        return GalHistory(sfh, smh)
+    else:
+        return sfh
+
+
+@partial(jjit, static_argnames="return_smh")
+def calc_sfh_galpop(sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB, return_smh=False):
+    """Calculate the Diffstar SFH for a single galaxy
+
+    Parameters
+    ----------
+    sfh_params : namedtuple, length 2
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of ndarrays of shape (ngals, )
+            ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    mah_params : namedtuple, length 4
+        mah_params is a tuple of ndarrays of shape (ngals, )
+        DiffmahParams = logmp, logtc, early_index, late_index
+
+    tarr : ndarray, shape (nt, )
+
+    lgt0 : float, optional
+        Base-10 log of the z=0 age of the Universe in Gyr
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    fb : float, optional
+        Cosmic baryon fraction Ob0/Om0
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    return_smh : bool, optional
+        If True, function return sfh, smh,
+        where smh is the history of stellar mass formed in units of Msun
+        Default is False, in which case function only returns sfh
+
+    Returns
+    -------
+    sfh : ndarray, shape (ngals, nt)
+        Star formation rate in units of Msun/yr
+
+    smh : ndarray, shape (ngals, nt), optional
+        Stellar mass in units of Msun
+        This variable is only returned if return_smh=True
+
+    """
+    ms_params, q_params = sfh_params
+    args = (tarr, *mah_params, *ms_params, *q_params, lgt0, fb)
+    sfh = _sfh_galpop_kern(*args)
+    if return_smh:
+        smh = _cumulative_mstar_formed_vmap(tarr, sfh)
+        return GalHistory(sfh, smh)
+    else:
+        return sfh

--- a/diffstar/tests/test_sfh_model_tpeak.py
+++ b/diffstar/tests/test_sfh_model_tpeak.py
@@ -1,0 +1,157 @@
+""""""
+
+import numpy as np
+from diffmah.defaults import DiffmahParams
+from jax import random as jran
+
+from ..defaults import (
+    DEFAULT_MS_PARAMS,
+    DEFAULT_Q_PARAMS,
+    DEFAULT_U_MS_PARAMS,
+    DEFAULT_U_Q_PARAMS,
+    FB,
+    LGT0,
+    SFR_MIN,
+    DiffstarParams,
+    DiffstarUParams,
+    MSParams,
+    MSUParams,
+    QParams,
+    QUParams,
+    get_bounded_diffstar_params,
+)
+from ..kernels.main_sequence_kernels import _get_bounded_sfr_params
+from ..kernels.quenching_kernels import _get_bounded_q_params
+from ..sfh import sfh_galpop, sfh_singlegal
+from ..sfh_model_tpeak import calc_sfh_galpop, calc_sfh_singlegal
+from .test_gas import _get_default_mah_params
+
+
+def _get_all_default_params():
+    ms_params, q_params = DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
+    all_mah_params = _get_default_mah_params()
+    lgt0, logmp, mah_logtc, k, early_index, late_index = all_mah_params
+    mah_params = logmp, mah_logtc, early_index, late_index
+    return lgt0, mah_params, ms_params, q_params
+
+
+def _get_all_default_u_params():
+    u_ms_params, u_q_params = DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS
+    all_mah_params = _get_default_mah_params()
+    lgt0, logmp, mah_logtc, k, early_index, late_index = all_mah_params
+    mah_params = logmp, mah_logtc, early_index, late_index
+    return lgt0, mah_params, u_ms_params, u_q_params
+
+
+def test_calc_sfh_singlegal_imports_from_top_level():
+    from .. import calc_sfh_singlegal  # noqa
+
+
+def test_calc_sfh_galpop_imports_from_top_level():
+    from .. import calc_sfh_galpop  # noqa
+
+
+def test_sfh_singlegal_evaluates():
+    lgt0, mah_params, ms_params, q_params = _get_all_default_params()
+
+    n_t = 100
+    tarr = np.linspace(0.1, 10**lgt0, n_t)
+    sfh = sfh_singlegal(tarr, mah_params, ms_params, q_params, LGT0, FB)
+    assert np.all(np.isfinite(sfh))
+    assert np.all(sfh >= SFR_MIN)
+    assert sfh.shape == (n_t,)
+
+
+def test_calc_sfh_smh_singlegal_agrees_with_sfh_singlegal_on_defaults():
+    lgt0, mah_params, ms_params, q_params = _get_all_default_params()
+
+    n_t = 100
+    tarr = np.linspace(0.1, 10**lgt0, n_t)
+    sfh = sfh_singlegal(tarr, mah_params, ms_params, q_params, lgt0, FB)
+
+    sfh_params = DiffstarParams(MSParams(*ms_params), QParams(*q_params))
+    sfh_new = calc_sfh_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+
+    assert np.allclose(sfh, sfh_new, rtol=1e-4)
+
+
+def test_calc_sfh_smh_singlegal_agrees_with_sfh_singlegal_on_randoms():
+    lgt0, mah_params, u_ms_params_init, u_q_params_init = _get_all_default_u_params()
+
+    n_t = 100
+    tarr = np.linspace(0.1, 10**lgt0, n_t)
+
+    ran_key = jran.PRNGKey(0)
+    ntests = 20
+    ran_keys = jran.split(ran_key, ntests)
+    for test_key in ran_keys:
+        ms_key, q_key = jran.split(test_key, 2)
+        u_ms_params = jran.normal(ms_key, shape=(5,)) + np.array(u_ms_params_init)
+        u_q_params = jran.normal(q_key, shape=(4,)) + np.array(u_q_params_init)
+        ms_params = _get_bounded_sfr_params(*u_ms_params)
+        q_params = _get_bounded_q_params(*u_q_params)
+        sfh = sfh_singlegal(tarr, mah_params, ms_params, q_params, lgt0, FB)
+
+        sfh_params = DiffstarParams(MSParams(*ms_params), QParams(*q_params))
+        sfh_new = calc_sfh_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+
+        assert np.allclose(sfh, sfh_new, rtol=1e-4)
+
+
+def test_calc_sfh_smh_singlegal_agrees_with_sfh_singlegal_on_u_randoms():
+    lgt0, mah_params, u_ms_params_init, u_q_params_init = _get_all_default_u_params()
+
+    n_t = 100
+    tarr = np.linspace(0.1, 10**lgt0, n_t)
+
+    ran_key = jran.PRNGKey(0)
+    ntests = 20
+    ran_keys = jran.split(ran_key, ntests)
+    for test_key in ran_keys:
+        ms_key, q_key = jran.split(test_key, 2)
+        u_ms_params = jran.normal(ms_key, shape=(5,)) + np.array(u_ms_params_init)
+        u_q_params = jran.normal(q_key, shape=(4,)) + np.array(u_q_params_init)
+        sfh = sfh_singlegal(
+            tarr,
+            mah_params,
+            u_ms_params,
+            u_q_params,
+            lgt0,
+            FB,
+            ms_param_type="unbounded",
+            q_param_type="unbounded",
+        )
+        sfh_u_params = DiffstarUParams(MSUParams(*u_ms_params), QUParams(*u_q_params))
+        sfh_params = get_bounded_diffstar_params(sfh_u_params)
+        sfh_new = calc_sfh_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+        assert np.allclose(sfh, sfh_new, rtol=1e-4)
+
+        sfh_new2, smh_new2 = calc_sfh_singlegal(
+            sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB, return_smh=True
+        )
+        assert np.allclose(sfh_new, sfh_new2)
+        assert np.all(np.isfinite(smh_new2))
+
+
+def test_calc_sfh_smh_galpop_agrees_with_sfh_galpop():
+    n_t = 100
+    lgt0, mah_params, ms_params, q_params = _get_all_default_params()
+    mah_params = np.array(mah_params).reshape((1, -1))
+    ms_params = np.array(ms_params).reshape((1, -1))
+    q_params = np.array(q_params).reshape((1, -1))
+    tarr = np.linspace(0.1, 10**lgt0, n_t)
+    sfh = sfh_galpop(tarr, mah_params, ms_params, q_params)
+
+    lgt0, mah_params, ms_params, q_params = _get_all_default_params()
+    zz = np.zeros(1)
+    mah_params = DiffmahParams(*[zz + p for p in mah_params])
+    ms_params = MSParams(*[zz + p for p in ms_params])
+    q_params = QParams(*[zz + p for p in q_params])
+    sfh_params = DiffstarParams(ms_params, q_params)
+    sfh_new = calc_sfh_galpop(sfh_params, mah_params, tarr)
+    assert np.allclose(sfh, sfh_new)
+    assert sfh_new.shape == (1, n_t)
+
+    sfh_new2, smh_new2 = calc_sfh_galpop(sfh_params, mah_params, tarr, return_smh=True)
+    assert np.allclose(sfh_new, sfh_new2)
+    assert np.all(np.isfinite(smh_new2))

--- a/diffstar/tests/test_sfh_model_tpeak.py
+++ b/diffstar/tests/test_sfh_model_tpeak.py
@@ -44,11 +44,11 @@ def _get_all_default_u_params():
 
 
 def test_calc_sfh_singlegal_imports_from_top_level():
-    from .. import calc_sfh_singlegal  # noqa
+    from .. import calc_sfh_singlegal as _func  # noqa
 
 
 def test_calc_sfh_galpop_imports_from_top_level():
-    from .. import calc_sfh_galpop  # noqa
+    from .. import calc_sfh_galpop as _func  # noqa
 
 
 def test_sfh_singlegal_evaluates():
@@ -70,7 +70,8 @@ def test_calc_sfh_smh_singlegal_agrees_with_sfh_singlegal_on_defaults():
     sfh = sfh_singlegal(tarr, mah_params, ms_params, q_params, lgt0, FB)
 
     sfh_params = DiffstarParams(MSParams(*ms_params), QParams(*q_params))
-    sfh_new = calc_sfh_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+    t_peak = tarr[-1]
+    sfh_new = calc_sfh_singlegal(sfh_params, mah_params, t_peak, tarr, lgt0=lgt0, fb=FB)
 
     assert np.allclose(sfh, sfh_new, rtol=1e-4)
 
@@ -93,7 +94,10 @@ def test_calc_sfh_smh_singlegal_agrees_with_sfh_singlegal_on_randoms():
         sfh = sfh_singlegal(tarr, mah_params, ms_params, q_params, lgt0, FB)
 
         sfh_params = DiffstarParams(MSParams(*ms_params), QParams(*q_params))
-        sfh_new = calc_sfh_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+        t_peak = tarr[-1]
+        sfh_new = calc_sfh_singlegal(
+            sfh_params, mah_params, t_peak, tarr, lgt0=lgt0, fb=FB
+        )
 
         assert np.allclose(sfh, sfh_new, rtol=1e-4)
 
@@ -123,11 +127,14 @@ def test_calc_sfh_smh_singlegal_agrees_with_sfh_singlegal_on_u_randoms():
         )
         sfh_u_params = DiffstarUParams(MSUParams(*u_ms_params), QUParams(*u_q_params))
         sfh_params = get_bounded_diffstar_params(sfh_u_params)
-        sfh_new = calc_sfh_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+        t_peak = tarr[-1]
+        sfh_new = calc_sfh_singlegal(
+            sfh_params, mah_params, t_peak, tarr, lgt0=lgt0, fb=FB
+        )
         assert np.allclose(sfh, sfh_new, rtol=1e-4)
 
         sfh_new2, smh_new2 = calc_sfh_singlegal(
-            sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB, return_smh=True
+            sfh_params, mah_params, t_peak, tarr, lgt0=lgt0, fb=FB, return_smh=True
         )
         assert np.allclose(sfh_new, sfh_new2)
         assert np.all(np.isfinite(smh_new2))
@@ -148,10 +155,13 @@ def test_calc_sfh_smh_galpop_agrees_with_sfh_galpop():
     ms_params = MSParams(*[zz + p for p in ms_params])
     q_params = QParams(*[zz + p for p in q_params])
     sfh_params = DiffstarParams(ms_params, q_params)
-    sfh_new = calc_sfh_galpop(sfh_params, mah_params, tarr)
+    t_peak = np.zeros(1) + tarr[-1]
+    sfh_new = calc_sfh_galpop(sfh_params, mah_params, t_peak, tarr)
     assert np.allclose(sfh, sfh_new)
     assert sfh_new.shape == (1, n_t)
 
-    sfh_new2, smh_new2 = calc_sfh_galpop(sfh_params, mah_params, tarr, return_smh=True)
+    sfh_new2, smh_new2 = calc_sfh_galpop(
+        sfh_params, mah_params, t_peak, tarr, return_smh=True
+    )
     assert np.allclose(sfh_new, sfh_new2)
     assert np.all(np.isfinite(smh_new2))


### PR DESCRIPTION
Add new convenience kernel for t_peak-based models. The new kernel has the following signature:

```
def calc_sfh_singlegal(sfh_params, mah_params, t_peak, tarr, lgt0=LGT0, fb=FB, return_smh=False):
    return sfh
```
Notice that `t_peak` is a new positional argument.

@alexalar be aware that this PR does not change the following lines from `__init__.py`:

`from .sfh_model import calc_sfh_galpop, calc_sfh_singlegal
`

That means that with the code in this PR, you need to explicitly import from `sfh_model_tpeak`, like this:
`from diffstar.sfh_model_tpeak import calc_sfh_galpop
`

If you instead import `calc_sfh_galpop` directly from `diffstar`, then you will be importing the old code that does not accept `t_peak` as a positional argument.