### PR TITLE
Fix bugs in unit tests of new tpeak-based SFH model

### DIFF
--- a/diffstar/data_loaders/load_smah_data.py
+++ b/diffstar/data_loaders/load_smah_data.py
@@ -1,16 +1,15 @@
 """
 """
+
 import os
 import warnings
 
 import h5py
 import numpy as np
+from umachine_pyio.load_mock import load_mock_from_binaries
 
 from ..defaults import SFR_MIN
 from ..utils import _get_dt_array
-
-from umachine_pyio.load_mock import load_mock_from_binaries
-
 
 TASSO = "/Users/aphearin/work/DATA/diffmah_data"
 BEBOP = "/lcrc/project/halotools/diffmah_data"

--- a/diffstar/fitting_helpers/fit_smah_helpers.py
+++ b/diffstar/fitting_helpers/fit_smah_helpers.py
@@ -1,5 +1,6 @@
 """
 """
+
 import os
 import warnings
 

--- a/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
+++ b/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
@@ -1,42 +1,33 @@
 """
 """
-import os
+
 import warnings
 
 import h5py
 import numpy as np
-
+from diffmah.defaults import LGT0
+from diffmah.diffmah_kernels import _diffmah_kern
 from jax import grad
 from jax import jit as jjit
 from jax import numpy as jnp
 
-from diffmah.diffmah_kernels import _diffmah_kern
-from diffmah.defaults import LGT0
-
 from ..defaults import (
-    DEFAULT_MS_PDICT,
-    DEFAULT_Q_PDICT,
-    DEFAULT_U_MS_PARAMS,
-    DEFAULT_U_Q_PARAMS,
     DEFAULT_MS_PARAMS,
+    DEFAULT_MS_PDICT,
     DEFAULT_Q_PARAMS,
+    DEFAULT_Q_PDICT,
 )
 from ..kernels.main_sequence_kernels_tpeak import (
-    _get_bounded_sfr_params_vmap,
     _get_bounded_sfr_params,
     _get_unbounded_sfr_params,
 )
 from ..kernels.quenching_kernels import (
-    _get_bounded_lg_drop,
-    _get_bounded_q_params_vmap,
     _get_bounded_q_params,
     _get_bounded_qt,
     _get_unbounded_q_params,
-    _get_unbounded_qrejuv,
 )
-from .fitting_kernels import calculate_sm_sfr_fstar_history_from_mah, compute_fstar
-
 from ..utils import _sigmoid
+from .fitting_kernels import calculate_sm_sfr_fstar_history_from_mah, compute_fstar
 
 T_FIT_MIN = 1.0  # Only fit snapshots above this threshold. Gyr units.
 DLOGM_CUT = 3.5  # Only fit SMH within this dex of the present day stellar mass.
@@ -52,7 +43,6 @@ def get_header():
     colnames.extend(list(DEFAULT_Q_PDICT.keys()))
     colnames.extend(["loss", "success"])
     header_str = "# " + " ".join(colnames) + "\n"
-    dtypes = []
     return header_str, colnames
 
 
@@ -130,7 +120,7 @@ def loss_default(params, loss_data):
     qt = _get_bounded_qt(u_q_params[0])
     loss += _sigmoid(qt - t_fstar_max, 0.0, 50.0, 100.0, 0.0)
     sfr_params = _get_bounded_sfr_params(*u_sfr_params)
-    (    
+    (
         lgmcrit,
         lgy_at_mcrit,
         indx_lo,
@@ -147,6 +137,7 @@ loss_grad_default = jjit(grad(loss_default, argnums=(0)))
 
 def loss_grad_default_np(params, data):
     return np.array(loss_grad_default(params, data)).astype(float)
+
 
 def get_loss_data_default(
     t_sim,
@@ -260,7 +251,6 @@ def get_loss_data_default(
         )
 
     logt = jnp.log10(t_sim)
-    logtmp = np.log10(t_sim[-1])
     dmhdt, log_mah = _diffmah_kern(mah_params, t_sim, t_peak, lgt0)
 
     weight, weight_fstar = get_weights(
@@ -458,7 +448,7 @@ def loss_default_clipssfrh(params, loss_data):
     loss += _sigmoid(qt - t_fstar_max, 0.0, 50.0, 100.0, 0.0)
 
     sfr_params = _get_bounded_sfr_params(*u_sfr_params)
-    (    
+    (
         lgmcrit,
         lgy_at_mcrit,
         indx_lo,

--- a/diffstar/fitting_helpers/fitting_kernels.py
+++ b/diffstar/fitting_helpers/fitting_kernels.py
@@ -1,5 +1,6 @@
 """
 """
+
 from diffmah.individual_halo_assembly import _calc_halo_history
 from jax import jit as jjit
 from jax import numpy as jnp
@@ -13,7 +14,6 @@ from ..kernels.main_sequence_kernels import (
     _sfr_eff_plaw,
 )
 from ..kernels.quenching_kernels import _quenching_kern_u_params
-from ..utils import jax_np_interp
 
 
 @jjit
@@ -235,10 +235,10 @@ def compute_fstar(tarr, mstar, fstar_tdelay):
 
     Notes
     -------
-    for t-fstar_tdelay < 0 t<tarr, and jnp.interp returns by default mstar[0], 
+    for t-fstar_tdelay < 0 t<tarr, and jnp.interp returns by default mstar[0],
     so fstar will always be positive.
     """
-    mstar_low = jnp.interp(tarr - fstar_tdelay, tarr, mstar) 
+    mstar_low = jnp.interp(tarr - fstar_tdelay, tarr, mstar)
     fstar = (mstar - mstar_low) / fstar_tdelay / 1e9
     fstar = jnp.where(fstar > 0.0, fstar, 0.0)
     return fstar

--- a/diffstar/fitting_helpers/tests/test_fitting_kernels.py
+++ b/diffstar/fitting_helpers/tests/test_fitting_kernels.py
@@ -1,5 +1,6 @@
 """
 """
+
 import numpy as np
 from diffmah.defaults import DEFAULT_MAH_PARAMS, MAH_K
 from diffmah.individual_halo_assembly import _calc_halo_history

--- a/diffstar/fitting_helpers/tests/test_fitting_smah_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_fitting_smah_helpers.py
@@ -1,5 +1,6 @@
 """
 """
+
 import numpy as np
 
 from ...defaults import DEFAULT_MS_PDICT, DEFAULT_Q_PDICT

--- a/diffstar/tests/test_main_sequence_kernels.py
+++ b/diffstar/tests/test_main_sequence_kernels.py
@@ -1,22 +1,18 @@
-import numpy as np
 import jax.numpy as jnp
-
-from diffstar.kernels.main_sequence_kernels import (
-    _lax_ms_sfh_scalar_kern_scan,
-    _lax_ms_sfh_scalar_kern_sum,
-)
-from diffstar.kernels.main_sequence_kernels import DEFAULT_MS_PARAMS
+import numpy as np
 from diffmah.defaults import DEFAULT_MAH_PARAMS, LGT0
-from diffstar.defaults import T_TABLE_MIN, TODAY
-from diffstar.defaults import FB
 
-from diffstar.kernels.main_sequence_kernels import (
-    _lax_ms_sfh_scalar_kern_sum as kern_sum,
-    _lax_ms_sfh_scalar_kern_scan as kern_scan,
-)
-from diffstar.kernels.main_sequence_kernels_tpeak import (
-    _lax_ms_sfh_scalar_kern_sum as kern_sum_tpeak,
+from ..defaults import FB, T_TABLE_MIN, TODAY
+from ..kernels.main_sequence_kernels import DEFAULT_MS_PARAMS
+from ..kernels.main_sequence_kernels import _lax_ms_sfh_scalar_kern_scan
+from ..kernels.main_sequence_kernels import _lax_ms_sfh_scalar_kern_scan as kern_scan
+from ..kernels.main_sequence_kernels import _lax_ms_sfh_scalar_kern_sum
+from ..kernels.main_sequence_kernels import _lax_ms_sfh_scalar_kern_sum as kern_sum
+from ..kernels.main_sequence_kernels_tpeak import (
     _lax_ms_sfh_scalar_kern_scan as kern_scan_tpeak,
+)
+from ..kernels.main_sequence_kernels_tpeak import (
+    _lax_ms_sfh_scalar_kern_sum as kern_sum_tpeak,
 )
 
 
@@ -36,16 +32,41 @@ def test_main_sequence_kernels_lax_ms_sfh_scalar_kern_scan_vs_sum():
         atol=1e-6,
     )
 
+
 def test_main_sequence_kernels_tpeak():
 
     t_table = jnp.logspace(0, LGT0, 100)
     t_form = jnp.logspace(0, LGT0, 30)
     t_peak = 16.0
 
-    sfr_sum = np.array([kern_sum(x, DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, LGT0, FB, t_table) for x in t_form])
-    sfr_scan = np.array([kern_scan(x, DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, LGT0, FB, t_table) for x in t_form])
-    sfr_sum_tpeak = np.array([kern_sum_tpeak(x, DEFAULT_MAH_PARAMS, t_peak, DEFAULT_MS_PARAMS, LGT0, FB, t_table) for x in t_form])
-    sfr_scan_tpeak = np.array([kern_scan_tpeak(x, DEFAULT_MAH_PARAMS, t_peak, DEFAULT_MS_PARAMS, LGT0, FB, t_table) for x in t_form])
+    sfr_sum = np.array(
+        [
+            kern_sum(x, DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, LGT0, FB, t_table)
+            for x in t_form
+        ]
+    )
+    sfr_scan = np.array(
+        [
+            kern_scan(x, DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, LGT0, FB, t_table)
+            for x in t_form
+        ]
+    )
+    sfr_sum_tpeak = np.array(
+        [
+            kern_sum_tpeak(
+                x, DEFAULT_MAH_PARAMS, t_peak, DEFAULT_MS_PARAMS, LGT0, FB, t_table
+            )
+            for x in t_form
+        ]
+    )
+    sfr_scan_tpeak = np.array(
+        [
+            kern_scan_tpeak(
+                x, DEFAULT_MAH_PARAMS, t_peak, DEFAULT_MS_PARAMS, LGT0, FB, t_table
+            )
+            for x in t_form
+        ]
+    )
 
     assert np.allclose(sfr_sum, sfr_sum_tpeak)
     assert np.allclose(sfr_scan, sfr_scan_tpeak)

--- a/diffstar/tests/test_main_sequence_kernels.py
+++ b/diffstar/tests/test_main_sequence_kernels.py
@@ -54,7 +54,7 @@ def test_main_sequence_kernels_tpeak():
     sfr_sum_tpeak = np.array(
         [
             kern_sum_tpeak(
-                x, DEFAULT_MAH_PARAMS, t_peak, DEFAULT_MS_PARAMS, LGT0, FB, t_table
+                x, DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, t_peak, LGT0, FB, t_table
             )
             for x in t_form
         ]
@@ -62,7 +62,7 @@ def test_main_sequence_kernels_tpeak():
     sfr_scan_tpeak = np.array(
         [
             kern_scan_tpeak(
-                x, DEFAULT_MAH_PARAMS, t_peak, DEFAULT_MS_PARAMS, LGT0, FB, t_table
+                x, DEFAULT_MAH_PARAMS, DEFAULT_MS_PARAMS, t_peak, LGT0, FB, t_table
             )
             for x in t_form
         ]


### PR DESCRIPTION
This PR resolves a failing unit test. The failure was due to a bug in the test, not the source code: within the unit test, the new SFH kernel was just being called with the arguments in the wrong order.

@alexalar remember to use relative imports when importing diffstar from within diffstar (which is the only other change brought in with this PR). This PR supersedes #59 