### PR TITLE
Add flake8-pyproject to linting.yaml env

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -29,7 +29,8 @@ jobs:
             --file=requirements.txt
           python -m pip install --no-deps -e .
           conda install -y -q \
-            flake8
+            flake8 \
+            flake8-pyproject
 
       - name: lint
         shell: bash -l {0}


### PR DESCRIPTION
This lets us use `pyproject.toml` to specify linting errors that can be ignored in our source code.