### PR TITLE
Update diffstar fitter

### DIFF
--- a/diffstar/data_loaders/load_smah_data.py
+++ b/diffstar/data_loaders/load_smah_data.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 import os
 import warnings

--- a/diffstar/data_loaders/load_smah_data.py
+++ b/diffstar/data_loaders/load_smah_data.py
@@ -40,45 +40,6 @@ FB_TNG = 0.0486 / 0.3089  # 0,15733
 H_TNG = 0.6774
 
 
-def load_fit_mah(basename, data_drn=BEBOP):
-    """Load the best fit diffmah parameter data
-
-    Parameters
-    ----------
-    basename : string
-        Name of the h5 file where the diffmah best fit parameters are stored
-
-    data_drn : string
-        Filepath where the Diffstar best-fit parameters are stored
-
-    Returns
-    -------
-    mah_fit_params:  ndarray of shape (n_gal, 4)
-        Best fit parameters for each halo:
-            (logtc, k, early_index, late_index)
-
-    logmp:  ndarray of shape (n_gal, )
-        Base-10 logarithm of the present day peak halo mass
-
-    logmp:  ndarray of shape (n_gal, )
-        Base-10 logarithm of the present day peak halo mass
-    """
-
-    fn = os.path.join(data_drn, basename)
-    with h5py.File(fn, "r") as hdf:
-        mah_fit_params = np.array(
-            [
-                hdf["logm0"][:],
-                hdf["logtc"][:],
-                hdf["early_index"][:],
-                hdf["late_index"][:],
-            ]
-        ).T
-        logmp = hdf["logm0"][:]
-
-    return mah_fit_params, logmp
-
-
 def load_fit_mah_tpeak(basename, data_drn=BEBOP):
     """Load the best fit diffmah parameter data
 
@@ -96,8 +57,9 @@ def load_fit_mah_tpeak(basename, data_drn=BEBOP):
         Best fit parameters for each halo:
             (logtc, k, early_index, late_index)
 
-    logmp:  ndarray of shape (n_gal, )
-        Base-10 logarithm of the present day peak halo mass
+    logm0:  ndarray of shape (n_gal, )
+        Diffmah parameter logm0
+
     """
 
     fn = os.path.join(data_drn, basename)
@@ -111,9 +73,9 @@ def load_fit_mah_tpeak(basename, data_drn=BEBOP):
                 hdf["t_peak"][:],
             ]
         ).T
-        logmp = hdf["logm0"][:]
+        logm0 = hdf["logm0"][:]
 
-    return mah_fit_params, logmp
+    return mah_fit_params, logm0
 
 
 def load_fit_sfh(basename, data_drn=BEBOP):
@@ -334,9 +296,9 @@ def load_tng_data(data_drn=BEBOP):
 
     log_mahs = halos["mpeakh"]
     log_mahs = np.maximum.accumulate(log_mahs, axis=1)
-    logmp = log_mahs[:, -1]
+    logmp0 = log_mahs[:, -1]
 
-    return halo_ids, log_smahs, sfrh, tng_t, dt, log_mahs, logmp
+    return halo_ids, log_smahs, sfrh, tng_t, dt, log_mahs, logmp0
 
 
 def load_tng_small_data(gal_type, data_drn=BEBOP):
@@ -558,9 +520,9 @@ def load_SMDPL_nomerging_data(subvols, data_drn=BEBOP_SMDPL):
     log_mahs = np.log10(clipped_mahs)
     log_mahs = np.maximum.accumulate(log_mahs, axis=1)
 
-    logmp = log_mahs[:, -1]
+    logmp0 = log_mahs[:, -1]
 
-    return halo_ids, log_smahs, sfrh, SMDPL_t, dt, log_mahs, logmp
+    return halo_ids, log_smahs, sfrh, SMDPL_t, dt, log_mahs, logmp0
 
 
 def load_SMDPL_DR1_data(subvols, data_drn=BEBOP_SMDPL_DR1):
@@ -622,6 +584,6 @@ def load_SMDPL_DR1_data(subvols, data_drn=BEBOP_SMDPL_DR1):
     log_mahs = np.log10(clipped_mahs)
     log_mahs = np.maximum.accumulate(log_mahs, axis=1)
 
-    logmp = log_mahs[:, -1]
+    logmp0 = log_mahs[:, -1]
 
-    return halo_ids, log_smahs, sfrh, SMDPL_t, dt, log_mahs, logmp
+    return halo_ids, log_smahs, sfrh, SMDPL_t, dt, log_mahs, logmp0

--- a/diffstar/data_loaders/load_smah_data.py
+++ b/diffstar/data_loaders/load_smah_data.py
@@ -1,12 +1,10 @@
 """ """
 
 import os
-import warnings
 
 import h5py
 import numpy as np
 
-from ..defaults import SFR_MIN
 from ..utils import cumulative_mstar_formed_galpop
 
 try:

--- a/diffstar/data_loaders/load_smah_data.py
+++ b/diffstar/data_loaders/load_smah_data.py
@@ -127,9 +127,6 @@ def load_bolshoi_data(gal_type, data_drn=BEBOP):
     The loaded stellar mass data has units of Msun assuming the h = H_BPL
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_BPL] using the h value of the simulation.
-
     H_BPL is defined at the top of the module.
 
     Parameters
@@ -149,10 +146,10 @@ def load_bolshoi_data(gal_type, data_drn=BEBOP):
         IDs of the halos in the file
 
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1
+        Cumulative stellar mass history in units of Msun assuming h in the simulation
 
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1
+        Star formation rate history in units of Msun/yr assuming h in the simulation
 
     bpl_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
@@ -186,9 +183,6 @@ def load_bolshoi_small_data(gal_type, data_drn=BEBOP):
     The loaded stellar mass data has units of Msun assuming the h = H_BPL
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_BPL] using the h value of the simulation.
-
     H_BPL is defined at the top of the module.
 
     Parameters
@@ -208,10 +202,10 @@ def load_bolshoi_small_data(gal_type, data_drn=BEBOP):
         IDs of the halos in the file
 
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1
+        Cumulative stellar mass history in units of Msun assuming h in the simulation
 
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1
+        Star formation rate history in units of Msun/yr assuming h in the simulation
 
     bpl_t : ndarray of shape (n_times, )
 
@@ -245,9 +239,6 @@ def load_tng_data(data_drn=BEBOP):
     The loaded stellar mass data has units of Msun assuming the h = H_TNG
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_TNG] using the h value of the simulation.
-
     H_TNG is defined at the top of the module.
 
     Parameters
@@ -267,10 +258,10 @@ def load_tng_data(data_drn=BEBOP):
         IDs of the halos in the file
 
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1
+        Cumulative stellar mass history in units of Msun assuming h in the simulation
 
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1
+        Star formation rate history in units of Msun/yr assuming h in the simulation
 
     tng_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
@@ -308,9 +299,6 @@ def load_tng_small_data(gal_type, data_drn=BEBOP):
     The loaded stellar mass data has units of Msun assuming the h = H_TNG
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_TNG] using the h value of the simulation.
-
     H_TNG is defined at the top of the module.
 
     Parameters
@@ -328,9 +316,9 @@ def load_tng_small_data(gal_type, data_drn=BEBOP):
     halo_ids:  ndarray of shape (n_gal, )
         IDs of the halos in the file.
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h in the simulation.
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h in the simulation.
     tng_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
     dt : ndarray of shape (n_times, )
@@ -361,9 +349,6 @@ def load_mdpl_data(gal_type, data_drn=BEBOP):
     The loaded stellar mass data has units of Msun assuming the h = H_MDPL
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_MDPL] using the h value of the simulation.
-
     H_MDPL is defined at the top of the module.
 
     Parameters
@@ -381,9 +366,9 @@ def load_mdpl_data(gal_type, data_drn=BEBOP):
     halo_ids:  ndarray of shape (n_gal, )
         IDs of the halos in the file.
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h in the simulation.
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h in the simulation.
     mdpl_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
     dt : ndarray of shape (n_times, )
@@ -415,9 +400,6 @@ def load_mdpl_small_data(gal_type, data_drn=BEBOP):
     The loaded stellar mass data has units of Msun assuming the h = H_MDPL
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_MDPL] using the h value of the simulation.
-
     H_MDPL is defined at the top of the module.
 
     Parameters
@@ -435,9 +417,9 @@ def load_mdpl_small_data(gal_type, data_drn=BEBOP):
     halo_ids:  ndarray of shape (n_gal, )
         IDs of the halos in the file.
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h in the simulation.
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h in the simulation.
     mdpl_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
     dt : ndarray of shape (n_times, )
@@ -468,9 +450,6 @@ def load_SMDPL_nomerging_data(subvols, data_drn=BEBOP_SMDPL):
     The loaded stellar mass data has units of Msun assuming the h = H_BPL
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_BPL] using the h value of the simulation.
-
     H_BPL is defined at the top of the module.
 
     Parameters
@@ -488,9 +467,9 @@ def load_SMDPL_nomerging_data(subvols, data_drn=BEBOP_SMDPL):
     halo_ids:  ndarray of shape (n_gal, )
         IDs of the halos in the file.
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h in the simulation.
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h in the simulation.
     bpl_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
     dt : ndarray of shape (n_times, )
@@ -532,9 +511,6 @@ def load_SMDPL_DR1_data(subvols, data_drn=BEBOP_SMDPL_DR1):
     The loaded stellar mass data has units of Msun assuming the h = H_BPL
     from the cosmology of the underlying simulation.
 
-    The output stellar mass data has units of Msun/h, or units of
-    Mstar[h=H_BPL] using the h value of the simulation.
-
     H_BPL is defined at the top of the module.
 
     Parameters
@@ -552,9 +528,9 @@ def load_SMDPL_DR1_data(subvols, data_drn=BEBOP_SMDPL_DR1):
     halo_ids:  ndarray of shape (n_gal, )
         IDs of the halos in the file.
     log_smahs: ndarray of shape (n_gal, n_times)
-        Cumulative stellar mass history in units of Msun assuming h=1.
+        Cumulative stellar mass history in units of Msun assuming h=0.67.
     sfrh: ndarray of shape (n_gal, n_times)
-        Star formation rate history in units of Msun/yr assuming h=1.
+        Star formation rate history in units of Msun/yr assuming h=0.67.
     bpl_t : ndarray of shape (n_times, )
         Cosmic time of each simulated snapshot in Gyr
     dt : ndarray of shape (n_times, )

--- a/diffstar/data_loaders/tests/test_load_smah_data.py
+++ b/diffstar/data_loaders/tests/test_load_smah_data.py
@@ -1,11 +1,10 @@
-"""
-"""
+""" """
 
 import os
 
 import numpy as np
 
-from ..load_smah_data import load_fit_mah_tpeak
+from ..load_smah_data import load_smdpl_diffmah_fits
 
 _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
 
@@ -13,17 +12,16 @@ _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
 def test_load_fit_mah_tpeak():
     basename = "subvol_000_diffmah_fits.h5"
     data_drn = os.path.join(_THIS_DRNAME, "testing_data")
-    _res = load_fit_mah_tpeak(basename, data_drn=data_drn)
+    _res = load_smdpl_diffmah_fits(basename, data_drn=data_drn)
     for x in _res:
         assert np.all(np.isfinite(x))
-    mah_fit_params, logmp = _res
-    n_halos, n_params = mah_fit_params.shape
+    mah_params, logmp0, loss, n_points_per_fit = _res
+    n_halos = mah_params.logm0.size
 
-    assert logmp.shape == (n_halos,)
-    assert np.all(logmp > 10)
-    assert np.all(logmp < 16)
+    assert logmp0.shape == (n_halos,)
+    assert np.all(logmp0 > 10)
+    assert np.all(logmp0 < 16)
 
-    t_peak = mah_fit_params[:, -1]
-    assert t_peak.shape == (n_halos,)
-    assert np.all(t_peak > 0)
-    assert np.all(t_peak < 14)
+    assert mah_params.t_peak.shape == (n_halos,)
+    assert np.all(mah_params.t_peak > 0)
+    assert np.all(mah_params.t_peak < 14)

--- a/diffstar/fitting_helpers/__init__.py
+++ b/diffstar/fitting_helpers/__init__.py
@@ -1,4 +1,4 @@
-"""
-"""
+""" """
+
 # flake8: noqa
 from .param_clippers import ms_param_clipper, q_param_clipper

--- a/diffstar/fitting_helpers/diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/diffstar_fitting_helpers.py
@@ -1,0 +1,146 @@
+""" """
+
+import warnings
+
+import h5py
+import numpy as np
+from diffmah.defaults import LGT0
+from diffmah.diffmah_kernels import _diffmah_kern
+from jax import grad
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from ..defaults import (
+    DEFAULT_MS_PARAMS,
+    DEFAULT_MS_PDICT,
+    DEFAULT_Q_PARAMS,
+    DEFAULT_Q_PDICT,
+)
+from ..kernels.main_sequence_kernels_tpeak import (
+    _get_bounded_sfr_params,
+    _get_unbounded_sfr_params,
+)
+from ..kernels.quenching_kernels import (
+    _get_bounded_q_params,
+    _get_bounded_qt,
+    _get_unbounded_q_params,
+)
+from ..utils import compute_fstar, cumulative_mstar_formed
+from .fitting_kernels import calculate_sm_sfr_fstar_history_from_mah
+
+T_FIT_MIN = 1.0  # Only fit snapshots above this threshold. Gyr units.
+DLOGM_CUT = 3.5  # Only fit SMH within this dex of the present day stellar mass.
+MIN_MASS_CUT = 7.0  # Only fit SMH above this threshold. Log10(Msun) units.
+FSTAR_TIME_DELAY = 1.0  # Time period of averaged SFH (aka fstar). Gyr units.
+SSFRH_FLOOR = 1e-12  # Clip SFH to this minimum sSFR value. 1/yr units.
+
+
+def get_loss_data_default(
+    t_table,
+    sfh_table,
+    mah_params,
+    dlogm_cut=DLOGM_CUT,
+    t_fit_min=T_FIT_MIN,
+    mass_fit_min=MIN_MASS_CUT,
+    fstar_tdelay=FSTAR_TIME_DELAY,
+    ssfrh_floor=SSFRH_FLOOR,
+    lgt0=LGT0,
+):
+    mstar_table = cumulative_mstar_formed(t_table, sfh_table)
+
+    fstar_table = compute_fstar(t_table, mstar_table, fstar_tdelay)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ssfrh = fstar_table / mstar_table
+        ssfrh = np.clip(ssfrh, ssfrh_floor, np.inf)
+        fstar_sim = ssfrh * mstar_table
+        log_fstar_sim = np.where(
+            fstar_sim == 0.0, np.log10(fstar_sim.max()) - 3.0, np.log10(fstar_sim)
+        )
+
+    logt = jnp.log10(t_table)
+    dmhdt, log_mah = _diffmah_kern(mah_params, t_table, lgt0)
+
+    weight, weight_fstar = get_weights(
+        t_table,
+        log_smah_sim,
+        log_fstar_sim,
+        fstar_tdelay,
+        dlogm_cut,
+        t_fit_min,
+        mass_fit_min,
+    )
+
+    t_fstar_max = logt[np.argmax(log_fstar_sim)]
+
+    default_sfr_params = np.array(DEFAULT_MS_PARAMS)
+    default_sfr_params[0] = np.clip(0.3 * (logmp0 - 11.0) + 11.4, 11.0, 13.0)
+    default_sfr_params[1] = np.clip(0.2 * (logmp0 - 11.0) - 0.7, -1.5, -0.2)
+    default_sfr_params[2] = np.clip(0.7 * (logmp0 - 11.0) - 0.3, 0.2, 3.0)
+    default_sfr_params[4] = np.clip(-8.0 * (logmp0 - 11.0) + 15, 2.0, 15.0)
+    u_default_sfr_params = np.array(_get_unbounded_sfr_params(*default_sfr_params))
+
+    sfr_ms_params = np.zeros(4)
+    sfr_ms_params[0:3] = u_default_sfr_params[0:3]
+    sfr_ms_params[3] = u_default_sfr_params[4]
+    fixed_hi = u_default_sfr_params[3]
+
+    sfr_ms_params_err = np.array([0.5, 0.5, 1.0, 3.0])
+
+    default_q_params = np.array(DEFAULT_Q_PARAMS)
+    default_q_params[0] = np.clip(-0.5 * (logmp0 - 11.0) + 1.5, 0.7, 1.5)
+    default_q_params[2] = -2.0
+    q_params = np.array(_get_unbounded_q_params(*default_q_params))
+    q_params_err = np.array([0.3, 0.5, 0.3, 0.3])
+
+    loss_data = (
+        logt,
+        dt,
+        dmhdt,
+        log_mah,
+        smh,
+        log_smah_sim,
+        sfh_table,
+        log_fstar_sim,
+        fstar_tdelay,
+        ssfrh_floor,
+        weight,
+        weight_fstar,
+        t_fstar_max,
+        fixed_hi,
+    )
+    p_init = (
+        np.concatenate((sfr_ms_params, q_params)),
+        np.concatenate((sfr_ms_params_err, q_params_err)),
+    )
+    return p_init, loss_data
+
+
+def get_weights(
+    t_table,
+    log_smah_sim,
+    log_fstar_sim,
+    fstar_tdelay,
+    dlogm_cut,
+    t_fit_min,
+    mass_fit_min,
+):
+    mass_fit_min = min(log_smah_sim[-1] - 0.5, mass_fit_min)
+
+    mask = log_smah_sim > (log_smah_sim[-1] - dlogm_cut)
+    mask &= log_smah_sim > mass_fit_min
+    mask &= t_table >= t_fit_min
+
+    weight = np.ones_like(t_table)
+    weight[~mask] = 1e10
+    weight[log_smah_sim[-1] - log_smah_sim < 0.1] = 0.5
+    weight = jnp.array(weight)
+
+    weight_fstar = np.ones_like(t_table)
+    weight_fstar[~mask] = 1e10
+    weight_fstar[log_fstar_sim.max() - log_fstar_sim < 0.1] = 0.5
+    weight_fstar[weight_fstar == -10.0] = 1e10
+    weight_fstar[t_table < fstar_tdelay + 0.01] = 1e10
+
+    return weight, weight_fstar

--- a/diffstar/fitting_helpers/diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/diffstar_fitting_helpers.py
@@ -91,7 +91,7 @@ def get_loss_data_default(
     mstar_target = cumulative_mstar_formed(t_table, sfh_table)
     logmstar_target = np.log10(mstar_target)
 
-    fstar_table = compute_fstar(t_table, logmstar_target, fstar_tdelay)
+    fstar_table = compute_fstar(t_table, mstar_target, fstar_tdelay)
     ssfrh_table = fstar_table / mstar_target
     ssfrh_target = np.clip(ssfrh_table, ssfrh_floor, np.inf)
 

--- a/diffstar/fitting_helpers/diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/diffstar_fitting_helpers.py
@@ -42,6 +42,7 @@ def diffstar_fitter(
     lgt0=LGT0,
     fb=FB,
 ):
+    """Run the diffstar fitter on the input SFH"""
     u_p_init_and_err, loss_data = get_loss_data_default(
         t_table,
         sfh_table,
@@ -61,12 +62,15 @@ def diffstar_fitter(
         loss_data,
     )
     varied_u_p_best, loss_best, success = _res
+
+    # Transform varied_u_p_best into p_best
     u_indx_hi = DEFAULT_DIFFSTAR_U_PARAMS.u_ms_params.u_indx_hi
     u_p_best = (*varied_u_p_best[:3], u_indx_hi, *varied_u_p_best[3:])
     u_ms_params = DEFAULT_MS_PARAMS._make(u_p_best[:5])
     u_q_params = DEFAULT_Q_PARAMS._make(u_p_best[5:])
     u_p_best = DEFAULT_DIFFSTAR_U_PARAMS._make((u_ms_params, u_q_params))
     p_best = get_bounded_diffstar_params(u_p_best)
+
     return p_best, loss_best, success
 
 
@@ -82,6 +86,7 @@ def get_loss_data_default(
     lgt0=LGT0,
     fb=FB,
 ):
+    """Get loss data to use with diffstar_fitter"""
     sfh_target = np.clip(sfh_table, SFR_MIN, np.inf)
     mstar_target = cumulative_mstar_formed(t_table, sfh_table)
     logmstar_target = np.log10(mstar_target)

--- a/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
+++ b/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
@@ -35,6 +35,31 @@ FSTAR_TIME_DELAY = 1.0  # Time period of averaged SFH (aka fstar). Gyr units.
 SSFRH_FLOOR = 1e-12  # Clip SFH to this minimum sSFR value. 1/yr units.
 
 
+def diffstar_fitter(
+    tarr,
+    dt,
+    sfrh,
+    lgsmah,
+    logmp0_halo,
+    mah_params,
+    mass_fit_min,
+    fstar_tdelay,
+    ssfrh_floor,
+):
+    """Fit simulated SFH with diffstar"""
+    p_init, loss_data = get_loss_data_default(
+        tarr,
+        dt,
+        sfrh,
+        lgsmah,
+        logmp0_halo,
+        mah_params,
+        mass_fit_min=mass_fit_min,
+        fstar_tdelay=fstar_tdelay,
+        ssfrh_floor=ssfrh_floor,
+    )
+
+
 def get_header():
     """ """
     colnames = ["halo_id"]

--- a/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
+++ b/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 import warnings
 

--- a/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
+++ b/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
@@ -35,31 +35,6 @@ FSTAR_TIME_DELAY = 1.0  # Time period of averaged SFH (aka fstar). Gyr units.
 SSFRH_FLOOR = 1e-12  # Clip SFH to this minimum sSFR value. 1/yr units.
 
 
-def diffstar_fitter(
-    tarr,
-    dt,
-    sfrh,
-    lgsmah,
-    logmp0_halo,
-    mah_params,
-    mass_fit_min,
-    fstar_tdelay,
-    ssfrh_floor,
-):
-    """Fit simulated SFH with diffstar"""
-    p_init, loss_data = get_loss_data_default(
-        tarr,
-        dt,
-        sfrh,
-        lgsmah,
-        logmp0_halo,
-        mah_params,
-        mass_fit_min=mass_fit_min,
-        fstar_tdelay=fstar_tdelay,
-        ssfrh_floor=ssfrh_floor,
-    )
-
-
 def get_header():
     """ """
     colnames = ["halo_id"]

--- a/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
+++ b/diffstar/fitting_helpers/fit_smah_helpers_tpeak.py
@@ -143,7 +143,7 @@ def get_loss_data_default(
     dt,
     sfrh,
     log_smah_sim,
-    logmp,
+    logmp0,
     mah_params,
     dlogm_cut=DLOGM_CUT,
     t_fit_min=T_FIT_MIN,
@@ -165,7 +165,7 @@ def get_loss_data_default(
         Star formation history of simulated snapshots in Msun/yr units.
     log_smah_sim : ndarray of shape (nt, )
         Base-10 log of cumulative stellar mass in Msun units.
-    logmp : float
+    logmp0 : float
         Base-10 log present day halo mass in Msun units.
     mah_params : ndarray of shape (4, )
         Best fit diffmah halo parameters. Includes (logtc, k, early, late).
@@ -264,10 +264,10 @@ def get_loss_data_default(
     t_fstar_max = logt[np.argmax(log_fstar_sim)]
 
     default_sfr_params = np.array(DEFAULT_MS_PARAMS)
-    default_sfr_params[0] = np.clip(0.3 * (logmp - 11.0) + 11.4, 11.0, 13.0)
-    default_sfr_params[1] = np.clip(0.2 * (logmp - 11.0) - 0.7, -1.5, -0.2)
-    default_sfr_params[2] = np.clip(0.7 * (logmp - 11.0) - 0.3, 0.2, 3.0)
-    default_sfr_params[4] = np.clip(-8.0 * (logmp - 11.0) + 15, 2.0, 15.0)
+    default_sfr_params[0] = np.clip(0.3 * (logmp0 - 11.0) + 11.4, 11.0, 13.0)
+    default_sfr_params[1] = np.clip(0.2 * (logmp0 - 11.0) - 0.7, -1.5, -0.2)
+    default_sfr_params[2] = np.clip(0.7 * (logmp0 - 11.0) - 0.3, 0.2, 3.0)
+    default_sfr_params[4] = np.clip(-8.0 * (logmp0 - 11.0) + 15, 2.0, 15.0)
     u_default_sfr_params = np.array(_get_unbounded_sfr_params(*default_sfr_params))
 
     sfr_ms_params = np.zeros(4)
@@ -278,7 +278,7 @@ def get_loss_data_default(
     sfr_ms_params_err = np.array([0.5, 0.5, 1.0, 3.0])
 
     default_q_params = np.array(DEFAULT_Q_PARAMS)
-    default_q_params[0] = np.clip(-0.5 * (logmp - 11.0) + 1.5, 0.7, 1.5)
+    default_q_params[0] = np.clip(-0.5 * (logmp0 - 11.0) + 1.5, 0.7, 1.5)
     default_q_params[2] = -2.0
     q_params = np.array(_get_unbounded_q_params(*default_q_params))
     q_params_err = np.array([0.3, 0.5, 0.3, 0.3])

--- a/diffstar/fitting_helpers/fitting_kernels.py
+++ b/diffstar/fitting_helpers/fitting_kernels.py
@@ -13,6 +13,7 @@ from ..kernels.main_sequence_kernels_tpeak import (
     _sfr_eff_plaw,
 )
 from ..kernels.quenching_kernels import _quenching_kern_u_params
+from ..utils import cumulative_mstar_formed
 
 
 @jjit
@@ -71,10 +72,11 @@ def calculate_sm_sfr_fstar_history_from_mah(
         SFH averaged over timescale fstar_tdelay in units of Msun/yr assuming h=1
 
     """
-    sfr = _sfr_history_from_mah(lgt, dt, dmhdt, log_mah, u_ms_params, u_q_params, fb=fb)
-    mstar = _integrate_sfr(sfr, dt)
+    sfh = _sfr_history_from_mah(lgt, dt, dmhdt, log_mah, u_ms_params, u_q_params, fb=fb)
+    tarr = 10**lgt
+    mstar = cumulative_mstar_formed(tarr, sfh)
     fstar = compute_fstar(10**lgt, mstar, fstar_tdelay)
-    return mstar, sfr, fstar
+    return mstar, sfh, fstar
 
 
 @jjit
@@ -119,9 +121,10 @@ def calculate_sm_sfr_history_from_mah(
         Star formation rate history in units of Msun/yr assuming h=1
 
     """
-    sfr = _sfr_history_from_mah(lgt, dt, dmhdt, log_mah, u_ms_params, u_q_params, fb=fb)
-    mstar = _integrate_sfr(sfr, dt)
-    return mstar, sfr
+    sfh = _sfr_history_from_mah(lgt, dt, dmhdt, log_mah, u_ms_params, u_q_params, fb=fb)
+    tarr = 10**lgt
+    mstar = cumulative_mstar_formed(tarr, sfh)
+    return mstar, sfh
 
 
 @jjit
@@ -197,12 +200,6 @@ def calculate_histories(
 calculate_histories_vmap = jjit(
     vmap(calculate_histories, in_axes=(None, None, 0, 0, 0, None, None))
 )
-
-
-@jjit
-def _integrate_sfr(sfr, dt):
-    """Calculate the cumulative stellar mass history."""
-    return jnp.cumsum(sfr * dt) * 1e9
 
 
 @jjit

--- a/diffstar/fitting_helpers/fitting_kernels.py
+++ b/diffstar/fitting_helpers/fitting_kernels.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 from diffmah import DEFAULT_MAH_PARAMS, mah_singlehalo
 from jax import jit as jjit

--- a/diffstar/fitting_helpers/stars.py
+++ b/diffstar/fitting_helpers/stars.py
@@ -1,5 +1,5 @@
-"""
-"""
+""" """
+
 import numpy as np
 
 from ..utils import _get_dt_array

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -52,7 +52,7 @@ def test_diffstar_fitter():
     n_times = 50
     t0_sim = 13.6
     fb_sim = 0.15
-    t_table = np.linspace(T_TABLE_MIN, t0_sim, n_times)
+    t_table = np.linspace(0.1, t0_sim, n_times)
 
     for __ in range(n_tests):
 
@@ -86,7 +86,7 @@ def test_diffstar_fitter():
         logsm_table = np.log10(mstar_table)
         logsm_table_best = np.log10(mstar_table_best)
         mean_abs_err = _mae(logsm_table, logsm_table_best)
-        assert mean_abs_err < 0.1
+        assert mean_abs_err < 0.2
 
 
 def test_loss_default_clipssfrh():

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -52,7 +52,7 @@ def test_diffstar_fitter():
     n_times = 50
     t0_sim = 13.6
     fb_sim = 0.15
-    t_table = np.linspace(0.1, t0_sim, n_times)
+    t_table = np.linspace(T_TABLE_MIN, t0_sim, n_times)
 
     for __ in range(n_tests):
 
@@ -83,10 +83,11 @@ def test_diffstar_fitter():
             return_smh=True,
         )
 
-        logsm_table = np.log10(mstar_table)
-        logsm_table_best = np.log10(mstar_table_best)
+        msk_t_fit = t_table > dfh.T_FIT_MIN
+        logsm_table = np.log10(mstar_table)[msk_t_fit]
+        logsm_table_best = np.log10(mstar_table_best)[msk_t_fit]
         mean_abs_err = _mae(logsm_table, logsm_table_best)
-        assert mean_abs_err < 0.2
+        assert mean_abs_err < 0.05
 
 
 def test_loss_default_clipssfrh():
@@ -166,8 +167,8 @@ def test_get_loss_data_default():
         assert np.all(weight_fstar >= 0)
 
         assert np.all(np.isfinite(log_fstar_table))
-        assert np.all(log_fstar_table > -20)
-        assert np.all(log_fstar_table < 0)
+        assert np.all(log_fstar_table > -10)
+        assert np.all(log_fstar_table < np.log10(sfh_table.max()))
 
         assert 10**lgt_fstar_max > t_table[0]
         assert 10**lgt_fstar_max < t_table[-1]

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -9,6 +9,23 @@ from ...utils import cumulative_mstar_formed
 from .. import diffstar_fitting_helpers as dfh
 
 
+def test_diffstar_fitter():
+    ran_key = jran.key(0)
+    n_tests = 10
+    n_times = 50
+    t0_sim = 13.6
+    fb_sim = 0.15
+    t_table = np.linspace(T_TABLE_MIN, t0_sim, n_times)
+
+    for __ in range(n_tests):
+        ran_key, sfh_key = jran.split(ran_key, 2)
+        sfh_table = jran.uniform(sfh_key, minval=0, maxval=100, shape=(n_times,))
+
+        p_best, loss_best, success = dfh.diffstar_fitter(
+            t_table, sfh_table, DEFAULT_MAH_PARAMS, lgt0=np.log10(t0_sim), fb=fb_sim
+        )
+
+
 def test_loss_default_clipssfrh():
     ran_key = jran.key(0)
     n_tests = 100

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -9,6 +9,29 @@ from ...utils import cumulative_mstar_formed
 from .. import diffstar_fitting_helpers as dfh
 
 
+def test_loss_default_clipssfrh():
+    ran_key = jran.key(0)
+    n_tests = 100
+    n_times = 200
+    t0_sim = 13.6
+    fb_sim = 0.15
+    t_table = np.linspace(T_TABLE_MIN, t0_sim, n_times)
+
+    for __ in range(n_tests):
+        ran_key, sfh_key = jran.split(ran_key, 2)
+        sfh_table = jran.uniform(sfh_key, minval=0, maxval=100, shape=(n_times,))
+
+        _res = dfh.get_loss_data_default(
+            t_table, sfh_table, DEFAULT_MAH_PARAMS, lgt0=np.log10(t0_sim), fb=fb_sim
+        )
+        u_p_init_and_err, loss_data = _res
+        u_p_init, u_p_init_err = u_p_init_and_err
+        loss_init = dfh.loss_default_clipssfrh(u_p_init, loss_data)
+        assert np.all(np.isfinite(loss_init))
+        assert loss_init > 0
+        assert loss_init < 1_000.0
+
+
 def test_get_loss_data_default():
     ran_key = jran.key(0)
     n_tests = 100

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -13,6 +13,8 @@ from ...defaults import (
 from ...utils import cumulative_mstar_formed
 from .. import diffstar_fitting_helpers as dfh
 
+LOSS_TOL = 0.1
+
 
 def _get_random_diffstar_params(ran_key):
     ms_key, q_key = jran.split(ran_key, 2)
@@ -48,12 +50,13 @@ def _mae(pred, target):
 
 def test_diffstar_fitter():
     ran_key = jran.key(0)
-    n_tests = 10
+    n_tests = 100
     n_times = 50
     t0_sim = 13.6
     fb_sim = 0.15
     t_table = np.linspace(T_TABLE_MIN, t0_sim, n_times)
 
+    loss_collector = []
     for __ in range(n_tests):
 
         ran_key, u_p_key = jran.split(ran_key, 2)
@@ -87,7 +90,9 @@ def test_diffstar_fitter():
         logsm_table = np.log10(mstar_table)[msk_t_fit]
         logsm_table_best = np.log10(mstar_table_best)[msk_t_fit]
         mean_abs_err = _mae(logsm_table, logsm_table_best)
-        assert mean_abs_err < 0.05
+        loss_collector.append(mean_abs_err)
+
+    assert np.mean(np.array(loss_collector) < LOSS_TOL) > 0.9
 
 
 def test_loss_default_clipssfrh():

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -1,0 +1,69 @@
+""" """
+
+import numpy as np
+from diffmah.defaults import DEFAULT_MAH_PARAMS
+from jax import random as jran
+
+from ...defaults import T_TABLE_MIN
+from ...utils import cumulative_mstar_formed
+from .. import diffstar_fitting_helpers as dfh
+
+
+def test_get_loss_data_default():
+    ran_key = jran.key(0)
+    n_tests = 100
+    n_times = 200
+    t0_sim = 13.6
+    fb_sim = 0.15
+    t_table = np.linspace(T_TABLE_MIN, t0_sim, n_times)
+
+    for __ in range(n_tests):
+        ran_key, sfh_key = jran.split(ran_key, 2)
+        sfh_table = jran.uniform(sfh_key, minval=0, maxval=100, shape=(n_times,))
+
+        _res = dfh.get_loss_data_default(
+            t_table, sfh_table, DEFAULT_MAH_PARAMS, lgt0=np.log10(t0_sim), fb=fb_sim
+        )
+        u_p_init_and_err, loss_data = _res
+        u_p_init, u_p_init_err = u_p_init_and_err
+        assert np.all(np.isfinite(u_p_init))
+        assert np.all(np.isfinite(u_p_init_err))
+        assert u_p_init.shape == u_p_init_err.shape
+
+        (
+            t_table,
+            mah_params,
+            mstar_table,
+            logmstar_table,
+            sfh_table,
+            log_fstar_table,
+            fstar_tdelay,
+            ssfrh_floor,
+            weight,
+            weight_fstar,
+            lgt_fstar_max,
+            u_fixed_hi,
+            lgt0,
+            fb,
+        ) = loss_data
+
+        assert np.allclose(mstar_table, 10**logmstar_table)
+        mstar_table2 = cumulative_mstar_formed(t_table, sfh_table)
+        assert np.allclose(mstar_table2, mstar_table)
+        assert weight.shape == (n_times,)
+        assert np.all(np.isfinite(weight))
+        assert np.all(weight >= 0)
+
+        assert weight_fstar.shape == (n_times,)
+        assert np.all(np.isfinite(weight_fstar))
+        assert np.all(weight_fstar >= 0)
+
+        assert np.all(np.isfinite(log_fstar_table))
+        assert np.all(log_fstar_table > -20)
+        assert np.all(log_fstar_table < 0)
+
+        assert 10**lgt_fstar_max > t_table[0]
+        assert 10**lgt_fstar_max < t_table[-1]
+
+        assert np.allclose(10**lgt0, t0_sim)
+        assert np.allclose(fb, fb_sim)

--- a/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
+++ b/diffstar/fitting_helpers/tests/test_diffstar_fitting_helpers.py
@@ -31,6 +31,10 @@ def test_loss_default_clipssfrh():
         assert loss_init > 0
         assert loss_init < 1_000.0
 
+        loss_grads = dfh.loss_grad_default_clipssfrh(u_p_init, loss_data)
+        assert np.all(np.isfinite(loss_grads))
+        assert not np.any(np.isclose(loss_grads, 0.0))
+
 
 def test_get_loss_data_default():
     ran_key = jran.key(0)

--- a/diffstar/fitting_helpers/utils.py
+++ b/diffstar/fitting_helpers/utils.py
@@ -1,5 +1,5 @@
-"""
-"""
+""" """
+
 import numpy as np
 from jax import jit as jjit
 from jax import value_and_grad

--- a/diffstar/sfh_model_tpeak.py
+++ b/diffstar/sfh_model_tpeak.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 from collections import namedtuple
 from functools import partial

--- a/diffstar/tests/test_utils.py
+++ b/diffstar/tests/test_utils.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 import numpy as np
 import pytest
@@ -95,3 +94,20 @@ def test_cumulative_mstar_formed_vmap():
     for ig in range(n_gals):
         smh_table_ig = utils.cumulative_mstar_formed(t_table, sfh_table_galpop[ig, :])
         assert np.allclose(smh_table_ig, smh_table_galpop[ig, :], rtol=1e-5)
+
+
+def test_compute_fstar():
+    ran_key = jran.key(0)
+    n_tests = 100
+    n_times = 200
+    t_table = np.linspace(T_TABLE_MIN, 13.8, n_times)
+
+    for __ in range(n_tests):
+        ran_key, sfh_key, fstar_key = jran.split(ran_key, 3)
+        sfh_table = jran.uniform(sfh_key, minval=0, maxval=100, shape=(n_times,))
+        mstar_table = utils.cumulative_mstar_formed(t_table, sfh_table)
+        fstar_tdelay = jran.uniform(fstar_key, minval=0, maxval=10.0, shape=())
+        fstar_history = utils.compute_fstar(t_table, mstar_table, fstar_tdelay)
+        assert np.all(np.isfinite(fstar_history))
+        assert np.all(fstar_history[1:] > 0)
+        assert np.all(fstar_history <= sfh_table.max())

--- a/diffstar/tests/test_utils.py
+++ b/diffstar/tests/test_utils.py
@@ -106,6 +106,7 @@ def test_compute_fstar():
         ran_key, sfh_key, fstar_key = jran.split(ran_key, 3)
         sfh_table = jran.uniform(sfh_key, minval=0, maxval=100, shape=(n_times,))
         mstar_table = utils.cumulative_mstar_formed(t_table, sfh_table)
+        assert np.all(mstar_table > 0)
         fstar_tdelay = jran.uniform(fstar_key, minval=0, maxval=10.0, shape=())
         fstar_history = utils.compute_fstar(t_table, mstar_table, fstar_tdelay)
         assert np.all(np.isfinite(fstar_history))

--- a/diffstar/utils.py
+++ b/diffstar/utils.py
@@ -328,7 +328,7 @@ def compute_fstar(tarr, mstar, fstar_tdelay):
     Returns
     -------
     fstar : ndarray of shape (n_times)
-        SFH averaged over timescale fstar_tdelay in units of Msun/yr assuming h=1
+        SFH averaged over timescale fstar_tdelay in units of Msun/yr
 
     Notes
     -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-diffmah>=0.7.0
+diffmah>=0.7.1
 numpy
 jax
 h5py

--- a/scripts/diffstar_fitting_script_umachine.py
+++ b/scripts/diffstar_fitting_script_umachine.py
@@ -120,16 +120,14 @@ if __name__ == "__main__":
         subvol_data_str = indir_sfh
 
         if args.sim_name == "DR1":
-            _data = load_SMDPL_DR1_data(subvolumes_i, subvol_data_str)
-            subvol_diffmah_str = f"diffmah_fits_subvol_{isubvol}.hdf5"
+            _sfh_data = load_SMDPL_DR1_data(subvolumes_i, subvol_data_str)
         elif args.sim_name == "DR1_nomerging":
-            _data = load_SMDPL_nomerging_data(subvolumes_i, subvol_data_str)
-            subvol_diffmah_str = f"{subvol_str}_diffmah_fits.h5"
+            _sfh_data = load_SMDPL_nomerging_data(subvolumes_i, subvol_data_str)
         else:
             raise NotImplementedError
+        halo_ids, log_smahs_sim, sfhs_sim, t_smdpl = _sfh_data[:4]
 
-        halo_ids, log_smahs_sim, sfhs_sim, t_smdpl = _data[:4]
-
+        subvol_diffmah_str = f"{subvol_str}_diffmah_fits.h5"
         _mah_fits = load_smdpl_diffmah_fits(subvol_diffmah_str, data_drn=indir_diffmah)
         mah_params, logmp0, diffmah_loss, n_points_per_diffmah_fit = _mah_fits
         has_diffmah_fit = (diffmah_loss > 0) & (logmp0 > logmp0_min)

--- a/scripts/diffstar_fitting_script_umachine.py
+++ b/scripts/diffstar_fitting_script_umachine.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
                 halo_id = halo_ids_for_rank[i]
                 lgsmah = log_smahs_for_rank[i, :]
                 sfh = sfh_sim_for_rank[i, :]
-                mah_params = DiffmahParams([x[i] for x in mah_params_for_rank])
+                mah_params = DiffmahParams(*[x[i] for x in mah_params_for_rank])
                 logmp0_halo = logmp0_for_rank[i]
                 halo_has_diffmah_fit = has_diffmah_fit_for_rank[i]
 

--- a/scripts/diffstar_fitting_script_umachine.py
+++ b/scripts/diffstar_fitting_script_umachine.py
@@ -1,0 +1,221 @@
+import argparse
+import os
+import subprocess
+from glob import glob
+from time import time
+
+import numpy as np
+from diffmah.diffmah_kernels import DiffmahParams
+from mpi4py import MPI
+
+import diffstar.fitting_helpers.diffstar_fitting_helpers as dfh
+from diffstar.data_loaders.load_smah_data import (
+    FB_SMDPL,
+    T0_SMDPL,
+    load_smdpl_diffmah_fits,
+    load_SMDPL_DR1_data,
+    load_SMDPL_nomerging_data,
+)
+
+LOGMP0_MIN = 10.5
+MIN_MASS_CUT = 7.0
+
+BEBOP_SMDPL = "/lcrc/project/galsampler/SMDPL/dr1_no_merging_upidh/sfh_binary_catalogs/a_1.000000/"
+BEBOP_SMDPL_MAH = (
+    "/lcrc/project/halotools/SMDPL/dr1_no_merging_upidh/diffmah_tpeak_fits/"
+)
+
+TMP_OUTPAT = "tmp_sfh_fits_rank_{0}.dat"
+NUM_SUBVOLS_SMDPL = 576
+
+
+if __name__ == "__main__":
+    comm = MPI.COMM_WORLD
+    rank, nranks = comm.Get_rank(), comm.Get_size()
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("outdir", help="Output directory")
+    # parser.add_argument("-outbase", help="Basename of the output hdf5 file")
+    parser.add_argument(
+        "-indir_diffmah", help="Directory of mah parameters", default=BEBOP_SMDPL_MAH
+    )
+    parser.add_argument("-indir_sfh", help="Input directory", default=BEBOP_SMDPL)
+    parser.add_argument(
+        "-sim_name", help="Simulation name", choices=["DR1", "DR1_nomerging"]
+    )
+    parser.add_argument(
+        "-fstar_tdelay",
+        help="Time interval in Gyr for fstar definition.",
+        type=float,
+        default=1.0,
+    )
+    parser.add_argument(
+        "-mass_fit_min",
+        help="Minimum mass included in stellar mass histories.",
+        type=float,
+        default=MIN_MASS_CUT,
+    )
+    parser.add_argument(
+        "-ssfrh_floor",
+        help="Clipping floor for sSFH",
+        type=float,
+        default=dfh.SSFRH_FLOOR,
+    )
+    parser.add_argument("-test", help="Short test run?", type=bool, default=False)
+    parser.add_argument("-istart", help="First subvolume in loop", type=int, default=0)
+    parser.add_argument("-iend", help="Last subvolume in loop", type=int, default=-1)
+    parser.add_argument(
+        "-num_subvols_tot", help="Total # subvols", type=int, default=NUM_SUBVOLS_SMDPL
+    )
+
+    parser.add_argument(
+        "-logmp0_min",
+        help="Minimum mass required to run the diffstar fitter",
+        type=float,
+        default=LOGMP0_MIN,
+    )
+
+    args = parser.parse_args()
+
+    indir_sfh = args.indir_sfh
+    indir_diffmah = args.indir_diffmah
+    # outbase = args.outbase
+    istart, iend = args.istart, args.iend
+    num_subvols_tot = args.num_subvols_tot  # needed for string formatting
+    logmp0_min = args.logmp0_min
+
+    HEADER, colnames_out = dfh.get_header()
+
+    kwargs = {
+        "fstar_tdelay": args.fstar_tdelay,
+        "mass_fit_min": args.mass_fit_min,
+        "ssfrh_floor": args.ssfrh_floor,
+    }
+
+    start = time()
+
+    all_avail_subvol_names = [
+        os.path.basename(drn) for drn in glob(os.path.join(indir_sfh, "subvol_*"))
+    ]
+    all_avail_subvolumes = [int(s.split("_")[1]) for s in all_avail_subvol_names]
+    all_avail_subvolumes = sorted(all_avail_subvolumes)
+
+    if args.test:
+        subvolumes = [
+            all_avail_subvolumes[0],
+        ]
+    else:
+        subvolumes = np.arange(istart, iend)
+
+    for isubvol in subvolumes:
+        comm.Barrier()
+        isubvol_start = time()
+
+        nchar_subvol = len(str(num_subvols_tot))
+        subvol_str = f"subvol_{isubvol:0{nchar_subvol}d}"
+
+        subvolumes_i = [isubvol]
+
+        subvol_data_str = indir_sfh
+
+        if args.sim_name == "DR1":
+            _data = load_SMDPL_DR1_data(subvolumes_i, subvol_data_str)
+            subvol_diffmah_str = f"diffmah_fits_subvol_{isubvol}.hdf5"
+        elif args.sim_name == "DR1_nomerging":
+            _data = load_SMDPL_nomerging_data(subvolumes_i, subvol_data_str)
+            subvol_diffmah_str = f"{subvol_str}_diffmah_fits.h5"
+        else:
+            raise NotImplementedError
+
+        halo_ids, log_smahs_sim, sfhs_sim, t_smdpl = _data[:4]
+
+        _mah_fits = load_smdpl_diffmah_fits(subvol_diffmah_str, data_drn=indir_diffmah)
+        mah_params, logmp0, diffmah_loss, n_points_per_diffmah_fit = _mah_fits
+        has_diffmah_fit = (diffmah_loss > 0) & (logmp0 > logmp0_min)
+
+        if rank == 0:
+            print("Number of galaxies in subvolume = {}".format(len(halo_ids)))
+
+        # Get data for rank
+        if args.test:
+            nhalos_tot = nranks * 5
+        else:
+            nhalos_tot = len(halo_ids)
+
+        indx_all = np.arange(0, nhalos_tot).astype("i8")
+        indx = np.array_split(indx_all, nranks)[rank]
+
+        halo_ids_for_rank = halo_ids[indx]
+        log_smahs_for_rank = log_smahs_sim[indx]
+        sfh_sim_for_rank = sfhs_sim[indx]
+        mah_params_for_rank = mah_params._make([x[indx] for x in mah_params])
+        logmp0_for_rank = logmp0[indx]
+        has_diffmah_fit_for_rank = has_diffmah_fit[indx]
+
+        nhalos_for_rank = len(halo_ids_for_rank)
+
+        rank_basepat = "_".join((subvol_str, TMP_OUTPAT))
+        rank_outname = os.path.join(args.outdir, rank_basepat).format(rank)
+
+        comm.Barrier()
+        with open(rank_outname, "w") as fout:
+            fout.write(HEADER)
+
+            for i in range(nhalos_for_rank):
+                halo_id = halo_ids_for_rank[i]
+                lgsmah = log_smahs_for_rank[i, :]
+                sfh = sfh_sim_for_rank[i, :]
+                mah_params = DiffmahParams([x[i] for x in mah_params_for_rank])
+                logmp0_halo = logmp0_for_rank[i]
+                halo_has_diffmah_fit = has_diffmah_fit_for_rank[i]
+
+                run_fitter = (mah_params > logmp0_min) & halo_has_diffmah_fit
+                if run_fitter:
+                    _res = dfh.diffstar_fitter(
+                        t_smdpl,
+                        sfh,
+                        mah_params,
+                        lgt0=np.log10(T0_SMDPL),
+                        fb=FB_SMDPL,
+                    )
+                    sfh_params_best, diffstar_loss, diffstar_fit_success = _res
+                    outline = dfh.get_outline(
+                        halo_id, sfh_params_best, diffstar_loss, diffstar_fit_success
+                    )
+                else:
+                    outline = dfh.get_outline_nofit(halo_id)
+
+                fout.write(outline)
+
+        comm.Barrier()
+        isubvol_end = time()
+
+        msg = "\n\nWallclock runtime to fit {0} galaxies with {1} ranks = {2:.1f} seconds\n\n"
+        if rank == 0:
+            print("\nFinished with subvolume {}".format(isubvol))
+            runtime = isubvol_end - isubvol_start
+            print(msg.format(nhalos_tot, nranks, runtime))
+
+            #  collate data from ranks and rewrite to disk
+            pat = os.path.join(args.outdir, rank_basepat)
+            fit_data_fnames = [pat.format(i) for i in range(nranks)]
+            collector = []
+            for fit_fn in fit_data_fnames:
+                assert os.path.isfile(fit_fn)
+                fit_data = np.genfromtxt(fit_fn, dtype="str")
+                collector.append(fit_data)
+            subvol_i_fit_results = np.concatenate(collector)
+
+            subvol_str = f"subvol_{isubvol:0{nchar_subvol}d}"
+            outbn = f"diffstar_fits_subvol_{isubvol}.hdf5"
+            outfn = os.path.join(args.outdir, outbn)
+
+            # fitsmah.write_collated_data(outfn, subvol_i_fit_results, chunk_arr=None)
+            dfh.write_collated_data(outfn, subvol_i_fit_results, colnames_out)
+
+            # clean up ASCII data for subvol_i
+            bnpat = subvol_str + "*.dat"
+            fnpat = os.path.join(args.outdir, bnpat)
+            command = "rm " + fnpat
+            subprocess.os.system(command)

--- a/scripts/diffstar_fitting_script_umachine.py
+++ b/scripts/diffstar_fitting_script_umachine.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
                 logmp0_halo = logmp0_for_rank[i]
                 halo_has_diffmah_fit = has_diffmah_fit_for_rank[i]
 
-                run_fitter = (mah_params > logmp0_min) & halo_has_diffmah_fit
+                run_fitter = (logmp0_halo > logmp0_min) & halo_has_diffmah_fit
                 if run_fitter:
                     _res = dfh.diffstar_fitter(
                         t_smdpl,

--- a/scripts/history_fitting_script_SMDPL_tpeak.py
+++ b/scripts/history_fitting_script_SMDPL_tpeak.py
@@ -108,17 +108,14 @@ if __name__ == "__main__":
 
         if args.sim_name == "DR1":
             _data = load_SMDPL_DR1_data(subvolumes_i, subvol_data_str)
+            subvol_diffmah_str = f"diffmah_fits_subvol_{isubvol}.hdf5"
         elif args.sim_name == "DR1_nomerging":
             _data = load_SMDPL_nomerging_data(subvolumes_i, subvol_data_str)
+            subvol_diffmah_str = f"{subvol_str}_diffmah_fits.h5"
         else:
             raise NotImplementedError
 
         halo_ids, log_smahs, sfrhs, tarr, dt, log_mahs, logmp = _data
-
-        if args.sim_name == "DR1":
-            subvol_diffmah_str = f"diffmah_fits_subvol_{isubvol}.hdf5"
-        elif args.sim_name == "DR1_nomerging":
-            subvol_diffmah_str = f"{subvol_str}_diffmah_fits.h5"
 
         mah_fit_params, logmp_fit = load_fit_mah_tpeak(
             subvol_diffmah_str, data_drn=indir_diffmah

--- a/scripts/history_fitting_script_SMDPL_tpeak.py
+++ b/scripts/history_fitting_script_SMDPL_tpeak.py
@@ -5,16 +5,16 @@ from glob import glob
 from time import time
 
 import numpy as np
+from diffmah.diffmah_kernels import DiffmahParams
 from mpi4py import MPI
 
 import diffstar.fitting_helpers.fit_smah_helpers_tpeak as fitsmah
 from diffstar.data_loaders.load_smah_data import (
     load_fit_mah_tpeak,
-    load_SMDPL_nomerging_data,
     load_SMDPL_DR1_data,
+    load_SMDPL_nomerging_data,
 )
 from diffstar.fitting_helpers.utils import minimizer_wrapper
-from diffmah.diffmah_kernels import DiffmahParams
 
 BEBOP_SMDPL = "/lcrc/project/galsampler/SMDPL/dr1_no_merging_upidh/sfh_binary_catalogs/a_1.000000/"
 BEBOP_SMDPL_MAH = (

--- a/scripts/history_fitting_script_SMDPL_tpeak.py
+++ b/scripts/history_fitting_script_SMDPL_tpeak.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-indir_diffmah", help="Directory of mah parameters", default=BEBOP_SMDPL_MAH
     )
-    parser.add_argument("-indir", help="Input directory", default=BEBOP_SMDPL)
+    parser.add_argument("-indir_sfh", help="Input directory", default=BEBOP_SMDPL)
     parser.add_argument(
         "-sim_name", help="Simulation name", choices=["DR1", "DR1_nomerging"]
     )
@@ -67,7 +67,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    indir = args.indir
+    indir_sfh = args.indir_sfh
     indir_diffmah = args.indir_diffmah
     # outbase = args.outbase
     istart, iend = args.istart, args.iend
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     start = time()
 
     all_avail_subvol_names = [
-        os.path.basename(drn) for drn in glob(os.path.join(indir, "subvol_*"))
+        os.path.basename(drn) for drn in glob(os.path.join(indir_sfh, "subvol_*"))
     ]
     all_avail_subvolumes = [int(s.split("_")[1]) for s in all_avail_subvol_names]
     all_avail_subvolumes = sorted(all_avail_subvolumes)
@@ -104,7 +104,7 @@ if __name__ == "__main__":
 
         subvolumes_i = [isubvol]
 
-        subvol_data_str = indir
+        subvol_data_str = indir_sfh
 
         if args.sim_name == "DR1":
             _data = load_SMDPL_DR1_data(subvolumes_i, subvol_data_str)

--- a/scripts/history_fitting_script_SMDPL_tpeak.py
+++ b/scripts/history_fitting_script_SMDPL_tpeak.py
@@ -115,9 +115,9 @@ if __name__ == "__main__":
         else:
             raise NotImplementedError
 
-        halo_ids, log_smahs, sfrhs, tarr, dt, log_mahs, logmp = _data
+        halo_ids, log_smahs, sfrhs, tarr, dt, log_mahs, logmp0 = _data
 
-        mah_fit_params, logmp_fit = load_fit_mah_tpeak(
+        mah_fit_params, __ = load_fit_mah_tpeak(
             subvol_diffmah_str, data_drn=indir_diffmah
         )
 
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         log_smahs_for_rank = log_smahs[indx]
         sfrhs_for_rank = sfrhs[indx]
         mah_params_for_rank = mah_fit_params[indx]
-        logmp_for_rank = logmp[indx]
+        logmp0_for_rank = logmp0[indx]
 
         nhalos_for_rank = len(halo_ids_for_rank)
 
@@ -153,10 +153,10 @@ if __name__ == "__main__":
                 lgsmah = log_smahs_for_rank[i, :]
                 sfrh = sfrhs_for_rank[i, :]
                 mah_params = DiffmahParams(*mah_params_for_rank[i])
-                logmp_halo = logmp_for_rank[i]
+                logmp0_halo = logmp0_for_rank[i]
 
                 p_init, loss_data = fitsmah.get_loss_data_default(
-                    tarr, dt, sfrh, lgsmah, logmp_halo, mah_params, **kwargs
+                    tarr, dt, sfrh, lgsmah, logmp0_halo, mah_params, **kwargs
                 )
                 _res = minimizer_wrapper(
                     fitsmah.loss_default_clipssfrh,

--- a/scripts/history_fitting_script_TNG.py
+++ b/scripts/history_fitting_script_TNG.py
@@ -1,16 +1,15 @@
 import argparse
 import os
 import subprocess
-from glob import glob
 from time import time
 
 import numpy as np
+from diffmah.diffmah_kernels import DiffmahParams
 from mpi4py import MPI
 
 import diffstar.fitting_helpers.fit_smah_helpers_tpeak as fitsmah
 from diffstar.data_loaders.load_smah_data import load_fit_mah_tpeak, load_tng_data
 from diffstar.fitting_helpers.utils import minimizer_wrapper
-from diffmah.diffmah_kernels import DiffmahParams
 
 BEBOP_TNG = "/lcrc/project/halotools/alarcon/data/"
 BEBOP_TNG_MAH = "/lcrc/project/halotools/alarcon/results/tng_diffmah_tpeak/"

--- a/scripts/run_umachine_smdpl_fitter.sh
+++ b/scripts/run_umachine_smdpl_fitter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# join error into standard out file <job_name>.o<job_id>
+#PBS -j oe
+
+# account to charge
+#PBS -A galsampler
+
+# allocate {select} nodes, each with {mpiprocs} MPI processes
+#PBS -l select=1:mpiprocs=20
+
+#PBS -l walltime=04:00:00
+
+# Load software
+source ~/.bash_profile
+cd ~/source/diffmah/scripts/
+
+# python diffstar_fitting_script_umachine.py /lcrc/project/halotools/random_data/0328 -sim_name DR1 -test 1

--- a/scripts/run_umachine_smdpl_fitter.sh
+++ b/scripts/run_umachine_smdpl_fitter.sh
@@ -15,4 +15,4 @@
 source ~/.bash_profile
 cd ~/source/diffmah/scripts/
 
-# python diffstar_fitting_script_umachine.py /lcrc/project/halotools/random_data/0328 -sim_name DR1 -test 1
+mpiexec -n 20 python diffstar_fitting_script_umachine.py /lcrc/project/halotools/random_data/0328 -sim_name DR1 -test

--- a/scripts/run_umachine_smdpl_fitter.sh
+++ b/scripts/run_umachine_smdpl_fitter.sh
@@ -13,6 +13,6 @@
 
 # Load software
 source ~/.bash_profile
-cd ~/source/diffmah/scripts/
+cd /home/ahearin/work/random/0328
 
-mpiexec -n 20 python diffstar_fitting_script_umachine.py /lcrc/project/halotools/random_data/0328 -sim_name DR1 -test
+mpiexec -n 20 python diffstar_fitting_script_umachine.py /lcrc/project/halotools/random_data/0328 -sim_name DR1 -istart 0 -iend 1


### PR DESCRIPTION
There is a new module `diffstar.fitting_helpers.diffstar_fitting_helpers.py` that implements the function `diffstar_fitter`:

```
def diffstar_fitter(t_table, sfh_table, mah_params, **kwargs):
    [code]
    return p_best, loss_best, success
```
Here the returned `p_best` is an actual namedtuple formatted just like `DEFAULT_DIFFSTAR_PARAMS`. And inside `[code]` we call the `get_loss_data_default` function, so that our scripts don't need to call anything besides `diffstar_fitter` after loading the target data.

I have also eliminated a bunch of reimplementations of kernels, and cleaned up the names of variables so that, for example, the log10 of `quantity` is named `log_quantity`, etc. I have also added a new unit test `test_diffstar_fitter` that randomly generates 10 SFHs in u-param space, creates target data, runs the fitter, and enforces that we recover a good-fitting result.

I think we can now delete `fitting_kernels.py` entirely. I have not yet rewritten the fitting script to use `diffstar_fitter`. I think we are not yet quite ready to delete `fit_smah_helpers_tpeak.py` because there are a couple of functions such as `get_header` and `write_collated_data` that still need to be ported into `diffstar_fitting_helpers.py`. 