### PR TITLE
Mgas

### DIFF
--- a/diffstar/__init__.py
+++ b/diffstar/__init__.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 # flake8: noqa
 from ._version import __version__
@@ -16,3 +15,4 @@ from .defaults import (
     get_unbounded_diffstar_params,
 )
 from .sfh_model_tpeak import calc_sfh_galpop, calc_sfh_singlegal
+from .mgas_model import calc_mgas_galpop, calc_mgas_singlegal

--- a/diffstar/mgas_model.py
+++ b/diffstar/mgas_model.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from functools import partial
 
 from jax import jit as jjit
 from jax import vmap

--- a/diffstar/mgas_model.py
+++ b/diffstar/mgas_model.py
@@ -1,0 +1,162 @@
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import vmap
+
+from diffstar.defaults import DEFAULT_N_STEPS, FB, LGT0, T_BIRTH_MIN
+from diffstar.kernels.history_kernel_builders_tpeak import build_sfh_from_mah_kernel
+from diffstar.utils import cumulative_mstar_formed, _jax_get_dt_array
+
+from diffmah.diffmah_kernels import mah_singlehalo, mah_halopop
+
+_sfh_singlegal_kern = build_sfh_from_mah_kernel(
+    n_steps=DEFAULT_N_STEPS,
+    tacc_integration_min=T_BIRTH_MIN,
+    tobs_loop="scan",
+    tform_loop="sum",
+)
+
+_sfh_galpop_kern = build_sfh_from_mah_kernel(
+    n_steps=DEFAULT_N_STEPS,
+    tacc_integration_min=T_BIRTH_MIN,
+    tobs_loop="scan",
+    galpop_loop="vmap",
+    tform_loop="sum",
+)
+
+_cumulative_mstar_formed_vmap = jjit(vmap(cumulative_mstar_formed, in_axes=(None, 0)))
+_jax_get_dt_array_vmap = jjit(vmap(_jax_get_dt_array, in_axes=(0)))
+
+GalHistory = namedtuple("GalHistory", ("sfh", "smh", "dmgash", "mgash"))
+
+
+@jjit
+def calc_mgas_singlegal(sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB):
+    """Calculate the Diffstar SFH for a single galaxy
+
+    Parameters
+    ----------
+    sfh_params : namedtuple, length 2
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+
+    mah_params : namedtuple, length 4
+        mah_params is a tuple of floats
+        DiffmahParams = logmp, logtc, early_index, late_index
+
+    t_peak : float
+
+    tarr : ndarray, shape (nt, )
+
+    lgt0 : float, optional
+        Base-10 log of the z=0 age of the Universe in Gyr
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    fb : float, optional
+        Cosmic baryon fraction Ob0/Om0
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+
+    Returns
+    -------
+    GalHistory namedtuple with 4 elements:
+
+        sfh : ndarray, shape (nt, )
+            Star formation rate in units of Msun/yr
+
+        smh : ndarray, shape (nt, )
+            Stellar mass in units of Msun
+
+        dmgas_dt : ndarray, shape (nt, )
+            Gas accretion rate - star formation rate, in units of Msun/yr
+
+        mgas : ndarray, shape (nt, )
+            Total remaining gas mass in units of Msun
+
+    """
+    ms_params, q_params = sfh_params
+    args = (tarr, *mah_params, *ms_params, *q_params, lgt0, fb)
+    sfh = _sfh_singlegal_kern(*args)
+
+    dmhdt, log_mah = mah_singlehalo(mah_params, tarr, lgt0)
+
+    dmgasdt_inst = fb * dmhdt
+    smh = cumulative_mstar_formed(tarr, sfh)
+    mgas_inst = cumulative_mstar_formed(tarr, dmgasdt_inst)
+    mgas = mgas_inst - smh
+
+    dt = _jax_get_dt_array(tarr)
+    dmgas_dt = _jax_get_dt_array(mgas) / dt / 1e9
+
+    return GalHistory(sfh, smh, dmgas_dt, mgas)
+
+
+@jjit
+def calc_mgas_galpop(sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB):
+    """Calculate the Diffstar SFH for a single galaxy
+
+    Parameters
+    ----------
+    sfh_params : namedtuple, length 2
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+
+    mah_params : namedtuple, length 4
+        mah_params is a tuple of floats
+        DiffmahParams = logmp, logtc, early_index, late_index
+
+    t_peak : float
+
+    tarr : ndarray, shape (nt, )
+
+    lgt0 : float, optional
+        Base-10 log of the z=0 age of the Universe in Gyr
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    fb : float, optional
+        Cosmic baryon fraction Ob0/Om0
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    Returns
+    -------
+    GalHistory namedtuple with 4 elements:
+
+        sfh : ndarray, shape (nt, )
+            Star formation rate in units of Msun/yr
+
+        smh : ndarray, shape (nt, )
+            Stellar mass in units of Msun
+
+        dmgas_dt : ndarray, shape (nt, )
+            Gas accretion rate - star formation rate, in units of Msun/yr
+
+        mgas : ndarray, shape (nt, )
+            Total remaining gas mass in units of Msun
+
+    """
+    ms_params, q_params = sfh_params
+    args = (tarr, *mah_params, *ms_params, *q_params, lgt0, fb)
+    sfh = _sfh_galpop_kern(*args)
+
+    dmhdt, log_mah = mah_halopop(mah_params, tarr, lgt0)
+
+    dmgasdt_inst = fb * dmhdt
+    smh = _cumulative_mstar_formed_vmap(tarr, sfh)
+    mgas_inst = _cumulative_mstar_formed_vmap(tarr, dmgasdt_inst)
+    mgas = mgas_inst - smh
+
+    dt = _jax_get_dt_array(tarr)
+    dmgas_dt = _jax_get_dt_array_vmap(mgas) / dt / 1e9
+
+    return GalHistory(sfh, smh, dmgas_dt, mgas)

--- a/diffstar/mgas_model.py
+++ b/diffstar/mgas_model.py
@@ -33,7 +33,7 @@ GalHistory = namedtuple("GalHistory", ("sfh", "smh", "dmgash", "mgash"))
 
 @jjit
 def calc_mgas_singlegal(sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB):
-    """Calculate the Diffstar SFH for a single galaxy
+    """Calculate the Diffstar SFH and Mgas for a single galaxy
 
     Parameters
     ----------
@@ -99,7 +99,7 @@ def calc_mgas_singlegal(sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB):
 
 @jjit
 def calc_mgas_galpop(sfh_params, mah_params, tarr, lgt0=LGT0, fb=FB):
-    """Calculate the Diffstar SFH for a single galaxy
+    """Calculate the Diffstar SFH and Mgas for a single galaxy
 
     Parameters
     ----------

--- a/diffstar/tests/test_mgas_model.py
+++ b/diffstar/tests/test_mgas_model.py
@@ -1,0 +1,68 @@
+""""""
+
+import numpy as np
+from diffmah.diffmah_kernels import DEFAULT_MAH_PARAMS
+from jax import random as jran
+
+from ..defaults import (
+    DEFAULT_MS_PARAMS,
+    DEFAULT_Q_PARAMS,
+    DEFAULT_U_MS_PARAMS,
+    DEFAULT_U_Q_PARAMS,
+    FB,
+    LGT0,
+    DiffstarUParams,
+    MSUParams,
+    QUParams,
+    get_bounded_diffstar_params,
+)
+from ..mgas_model import calc_mgas_singlegal
+
+
+def _get_all_default_params():
+    ms_params, q_params = DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
+    return LGT0, DEFAULT_MAH_PARAMS, ms_params, q_params
+
+
+def _get_all_default_u_params():
+    u_ms_params, u_q_params = DEFAULT_U_MS_PARAMS, DEFAULT_U_Q_PARAMS
+    return LGT0, DEFAULT_MAH_PARAMS, u_ms_params, u_q_params
+
+
+def test_calc_mgas_singlegal_imports_from_top_level():
+    from .. import calc_mgas_singlegal as _func  # noqa
+
+
+def test_calc_mgas_galpop_imports_from_top_level():
+    from .. import calc_mgas_galpop as _func  # noqa
+
+
+def test_sfh_singlegal_evaluates_on_wide_param_range():
+    lgt0, mah_params, u_ms_params_init, u_q_params_init = _get_all_default_u_params()
+
+    n_t = 100
+    tarr = np.linspace(0.1, 10**lgt0, n_t)
+
+    ran_key = jran.PRNGKey(0)
+    ntests = 20
+    ran_keys = jran.split(ran_key, ntests)
+    for test_key in ran_keys:
+        ms_key, q_key = jran.split(test_key, 2)
+        u_ms_params = jran.normal(ms_key, shape=(5,)) + np.array(u_ms_params_init)
+        u_q_params = jran.normal(q_key, shape=(4,)) + np.array(u_q_params_init)
+        sfh_u_params = DiffstarUParams(MSUParams(*u_ms_params), QUParams(*u_q_params))
+        sfh_params = get_bounded_diffstar_params(sfh_u_params)
+        res = calc_mgas_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+        assert np.all(np.isfinite(res.sfh))
+        assert np.all(np.isfinite(res.smh))
+        assert np.all(np.isfinite(res.dmgash))
+        assert np.all(np.isfinite(res.mgash))
+
+        res2 = calc_mgas_singlegal(sfh_params, mah_params, tarr, lgt0=lgt0, fb=FB)
+
+        assert np.all(np.isfinite(res2.sfh))
+        assert np.all(np.isfinite(res2.smh))
+        assert np.all(np.isfinite(res2.dmgash))
+        assert np.all(np.isfinite(res2.mgash))
+        assert np.allclose(res.sfh, res2.sfh)
+        assert np.allclose(res.mgash, res2.mgash)


### PR DESCRIPTION
This PR brings in kernels to return the Diffstar predicted surviving Mgas. This is defined as the total accreted Mgas, minus all the gas mass that has been converted into stars.

The plot below (top panel) shows an example of the prediction of surviving Mgas from this kernels for IllustrisTNG diffmah and diffstar best-fit parameters.

<img width="1877" height="5159" alt="mgas_average_histories_w_residuals_IllustrisTNG (in+ex-situ)" src="https://github.com/user-attachments/assets/7aae048e-1a01-4b99-b309-426116aab57d" />
