### PR TITLE
Prepare release `v1.0.0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+1.0.0 (2025-10-01)
+------------------
+- Add new formulation of diffstar.
+- Include diffstarpop as a sub-package of diffstar.
+- See PR notes for details https://github.com/ArgonneCPAC/diffstar/pull/97.
+
+
 0.3.5 (2025-09-26)
 ------------------
 - Add modules and fitting scripts of new formulation of diffstar (https://github.com/ArgonneCPAC/diffstar/pull/89)


### PR DESCRIPTION
This PR updates the changelog for `v1.0.0` of diffstar. Changes summarized below:

1. The physical formulation of `diffstar` has changed from the model introduced in [Alarcon+22](https://arxiv.org/abs/2205.04273). There is no longer a convolution kernel between the gas mass accretion and the gas consumption timescale, and `dMstar/dt` is no longer proportional to `dMhalo/dt`, but is instead related directly to `Mhalo(t)` via a newly formulated star formation efficiency function. The new formulation improves the flexibility of the model, and reduces the memory footprint of the predictions for large galaxy populations by an order of magnitude. Further information about the new model formulation will be summarized in a forthcoming paper, Alarcon+25, in prep.
2. The parameters of `diffstar` are now encoded as a flat named tuple. This is distinct from the original formulation of a _nested_ named tuple `diffstar_params.ms_params` and `diffstar_params.q_params`.
3. There is a new sub-package, `diffstarpop`, which brings in a population-level model of SFHs. The `diffstarpop` model was previously developed in a separate repo, [ArgonneCPAC/diffstarpop](https://github.com/ArgonneCPAC/diffstarpop), which is now deprecated.