### PR TITLE
Add `SIMULATION_FIT_PARAMS` to top-level imports from diffstar.diffstarpop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
-1.0.2 (unreleased)
+1.0.2 (2026-05-06)
 ------------------
+- Bug fixed in satellite-specific quenching ingredient (https://github.com/ArgonneCPAC/diffstar/pull/112)
 - Monte Carlo SFH generators now have required kwargs lgt0 and fb (https://github.com/ArgonneCPAC/diffstar/pull/108)
 
 

--- a/diffstar/diffstarpop/__init__.py
+++ b/diffstar/diffstarpop/__init__.py
@@ -11,6 +11,9 @@ from .kernels.defaults_mgash import (
     get_bounded_diffstarpop_params,
     get_unbounded_diffstarpop_params,
 )
+from .kernels.params.params_diffstarpopfits_mgash import (
+    DiffstarPop_Params_Diffstarpopfits_mgash as SIMULATION_FIT_PARAMS,
+)
 from .mc_diffstarpop_mgash import (
     mc_diffstar_params_galpop,
     mc_diffstar_params_singlegal,

--- a/diffstar/diffstarpop/tests/test_imports.py
+++ b/diffstar/diffstarpop/tests/test_imports.py
@@ -1,0 +1,5 @@
+"""Tests of top-level imports from diffstar.diffstarpop"""
+
+
+def test_simulation_fits():
+    from .. import SIMULATION_FIT_PARAMS  # noqa


### PR DESCRIPTION
With this PR, you can now do this:

```
from diffstar.diffstarpop import SIMULATION_FIT_PARAMS
print(SIMULATION_FIT_PARAMS.keys()))

odict_keys(['smdpl_dr1_nomerging', 'smdpl_dr1', 'tng', 'galacticus_in_situ', 'galacticus_in_plus_ex_situ'])

```

Previously, you could only import this by drilling down into `diffstarpop.kernels`, and the dictionary had a very long and non-intuitive name (`DiffstarPop_Params_Diffstarpopfits_mgash`). I have not changed anything besides defining `SIMULATION_FIT_PARAMS` to be equal to this obscurely-named dictionary.