### PR TITLE
Fix broken import of `tw_ndhist_weighted`

### DIFF
--- a/diffstar/diffstarpop/loss_kernels/mstar_ssfr_loss_mgash_anyz.py
+++ b/diffstar/diffstarpop/loss_kernels/mstar_ssfr_loss_mgash_anyz.py
@@ -16,7 +16,12 @@ try:
 
     HAS_DIFFSKY = True
 except ImportError:
-    HAS_DIFFSKY = False
+    try:
+        from diffsky.diffndhist import tw_ndhist_weighted
+
+        HAS_DIFFSKY = True
+    except ImportError:
+        HAS_DIFFSKY = False
 
 N_TIMES = 20
 

--- a/diffstar/diffstarpop/loss_kernels/mstar_ssfr_loss_mgash_anyz.py
+++ b/diffstar/diffstarpop/loss_kernels/mstar_ssfr_loss_mgash_anyz.py
@@ -12,7 +12,7 @@ from ..kernels.defaults_mgash import (
 from ..mc_diffstarpop_mgash import mc_diffstar_sfh_galpop
 
 try:
-    from diffsky.diffndhist import tw_ndhist_weighted
+    from diffsky.soft_histograms.diffndhist import tw_ndhist_weighted
 
     HAS_DIFFSKY = True
 except ImportError:


### PR DESCRIPTION
This updates the import of the `tw_ndhist_weighted` according to its new location within `diffsky.soft_histograms` brought in by https://github.com/ArgonneCPAC/diffsky/pull/449. 